### PR TITLE
Removed comment char preceding mkdir commands in ipmitool build script

### DIFF
--- a/ipmitool/bldipmi.pl
+++ b/ipmitool/bldipmi.pl
@@ -56,10 +56,10 @@ if ($os eq "rh5") {
   $blddir = "/usr/src/packages";
 }
 
-#&runcmd("mkdir -p $blddir/SOURCES");
-#&runcmd("mkdir -p $blddir/SPECS");
-#&runcmd("mkdir -p $blddir/BUILD");
-#&runcmd("mkdir -p $blddir/RPMS");
+&runcmd("mkdir -p $blddir/SOURCES");
+&runcmd("mkdir -p $blddir/SPECS");
+&runcmd("mkdir -p $blddir/BUILD");
+&runcmd("mkdir -p $blddir/RPMS");
 
 # clean the env
 $cmd = "rm -rf $blddir/SOURCES/ipmitool*";


### PR DESCRIPTION
The commands to make build directories for ipmitool were commented out, requiring them to be made manually
