### PR TITLE
Additional changes required for ipmitool 1.8.18 support 

### DIFF
--- a/ipmitool/debian/changelog
+++ b/ipmitool/debian/changelog
@@ -1,7 +1,7 @@
 ipmitool-xcat (1.8.18) unstable; urgency=low
   * Upgrade to 1.8.18 version
 
- -- Victor Hu <vhu@us.ibm.com> Tue, May 30, 2017 14:41:01 -0400
+ -- Victor Hu <vhu@us.ibm.com> Tue, 30 May 2017 14:41:01 -0400 
 
 ipmitool-xcat (1.8.17-1) unstable; urgency=low
   * Make ipmitool exit gracefully when receiving `INT`, `TERM` or `HUP` signal.

--- a/ipmitool/ipmitool.spec
+++ b/ipmitool/ipmitool.spec
@@ -60,6 +60,7 @@ if [ "$RPM_BUILD_ROOT" ] && [ "$RPM_BUILD_ROOT" != "/" ]; then
 fi
 
 %files
+%dir %attr(-,root,root) /opt/xcat/bin/
 %attr(755,root,root) /opt/xcat/bin/ipmitool-xcat
 
 


### PR DESCRIPTION
Changes required for supporting Issue #19 
Based on comments after testing with PR #20 ..

* Added commit that will help clean up the ipmitool-xcat rpm when installed by itself and removed 
* changelog incorrect for debian control file 