### PR TITLE
Package the docopt/gevent/greenlet into xcat-dep

### DIFF
--- a/python-openbmc-dep/Build-note
+++ b/python-openbmc-dep/Build-note
@@ -1,0 +1,15 @@
+Build Notes
+
+1. To build rpm
+1) Install pip and python-devel
+   - wget https://bootstrap.pypa.io/get-pip.py
+   - python get-pip.py
+   - yum install python-devel
+2) Create an clean directory for pip package destination
+   - mkdir -p python-openbmc-dep
+3) pip install -U --force --prefix python-openbmc-dep docopt gevent
+3) rpmbuild -ba python-openbmc-dep.spec
+4) The rpm package is located at /root/rpmbuild/RPMS/ppc64le/python-openbmc-dep-1.0-snap201803090524.ppc64le.rpm
+
+2. To build .deb package
+Not support yet

--- a/python-openbmc-dep/python-openbmc-dep.spec
+++ b/python-openbmc-dep/python-openbmc-dep.spec
@@ -1,0 +1,60 @@
+Summary: xCAT openbmc python dependency
+Name: python-openbmc-dep
+Version: 1.0
+Release: %{?release:%{release}}%{!?release:snap%(date +"%Y%m%d%H%M")}
+Epoch: 1
+License: MIT-Equivalent
+Group: Applications/System
+Source: python-openbmc-dep-%{version}.tar.gz
+Packager: IBM Corp.
+Vendor: IBM Corp.
+Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
+Prefix: /opt/xcat
+BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
+
+#workaround for https://github.com/gevent/gevent/issues/685
+%define _python_bytecompile_errors_terminate_build 0
+
+%ifnos linux
+AutoReqProv: no
+%endif
+
+#BuildArch: noarch
+Requires: python-requests
+
+%description
+python-openbmc-dep provides docopt, gevent and greenlet python modules which xCAT-openbmc-py requires.
+
+%prep
+%setup -q -n python-openbmc-dep
+#pip install -U --force --prefix `pwd` docopt gevent
+
+%build
+
+%install
+rm -rf $RPM_BUILD_ROOT
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+install -m644 lib/python*/site-packages/*.py $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+install -m755 lib64/python*/site-packages/*.so $RPM_BUILD_ROOT/%{prefix}/lib/python/agent
+
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/gevent
+install -d $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/gevent/libev
+install -m755 lib64/python*/site-packages/gevent/*.* $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/gevent
+install -m755 lib64/python*/site-packages/gevent/libev/*.* $RPM_BUILD_ROOT/%{prefix}/lib/python/agent/gevent/libev
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root)
+%{prefix}
+
+%changelog
+
+%pre
+
+%post
+
+%preun
+


### PR DESCRIPTION
UT:
```
[root@boston02 ~]# rpmbuild -bb python-openbmc-dep.spec
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.e5pvQr
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd /root/rpmbuild/BUILD
+ rm -rf python-openbmc-dep
+ /usr/bin/gzip -dc /root/rpmbuild/SOURCES/python-openbmc-dep-1.0.tar.gz
+ /usr/bin/tar -xf -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd python-openbmc-dep
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.3fQqKx
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd python-openbmc-dep
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.j4xAED
+ umask 022
+ cd /root/rpmbuild/BUILD
+ '[' /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le '!=' / ']'
+ rm -rf /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le
++ dirname /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le
+ mkdir -p /root/rpmbuild/BUILDROOT
+ mkdir /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le
+ cd python-openbmc-dep
+ rm -rf /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le
+ install -d /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le//opt/xcat/lib/python/agent
+ install -m644 lib/python2.7/site-packages/docopt.py /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le//opt/xcat/lib/python/agent
+ install -m755 lib64/python2.7/site-packages/greenlet.so /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le//opt/xcat/lib/python/agent
+ install -d /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le//opt/xcat/lib/python/agent/gevent
+ install -d /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le//opt/xcat/lib/python/agent/gevent/libev
+ install -m755 lib64/python2.7/site-packages/gevent/__init__.py lib64/python2.7/site-packages/gevent/__init__.pyc lib64/python2.7/site-packages/gevent/_compat.py lib64/python2.7/site-packages/gevent/_compat.pyc lib64/python2.7/site-packages/gevent/_fileobjectcommon.py lib64/python2.7/site-packages/gevent/_fileobjectcommon.pyc lib64/python2.7/site-packages/gevent/_fileobjectposix.py lib64/python2.7/site-packages/gevent/_fileobjectposix.pyc lib64/python2.7/site-packages/gevent/_semaphore.pxd lib64/python2.7/site-packages/gevent/_semaphore.py lib64/python2.7/site-packages/gevent/_semaphore.pyc lib64/python2.7/site-packages/gevent/_semaphore.so lib64/python2.7/site-packages/gevent/_socket2.py lib64/python2.7/site-packages/gevent/_socket2.pyc lib64/python2.7/site-packages/gevent/_socket3.py lib64/python2.7/site-packages/gevent/_socketcommon.py lib64/python2.7/site-packages/gevent/_socketcommon.pyc lib64/python2.7/site-packages/gevent/_ssl2.py lib64/python2.7/site-packages/gevent/_ssl2.pyc lib64/python2.7/site-packages/gevent/_ssl3.py lib64/python2.7/site-packages/gevent/_ssl3.pyc lib64/python2.7/site-packages/gevent/_sslgte279.py lib64/python2.7/site-packages/gevent/_sslgte279.pyc lib64/python2.7/site-packages/gevent/_tblib.py lib64/python2.7/site-packages/gevent/_tblib.pyc lib64/python2.7/site-packages/gevent/_threading.py lib64/python2.7/site-packages/gevent/_threading.pyc lib64/python2.7/site-packages/gevent/_util.py lib64/python2.7/site-packages/gevent/_util.pyc lib64/python2.7/site-packages/gevent/_util_py2.py lib64/python2.7/site-packages/gevent/_util_py2.pyc lib64/python2.7/site-packages/gevent/ares.pyx lib64/python2.7/site-packages/gevent/ares.so lib64/python2.7/site-packages/gevent/backdoor.py lib64/python2.7/site-packages/gevent/backdoor.pyc lib64/python2.7/site-packages/gevent/baseserver.py lib64/python2.7/site-packages/gevent/baseserver.pyc lib64/python2.7/site-packages/gevent/builtins.py lib64/python2.7/site-packages/gevent/builtins.pyc lib64/python2.7/site-packages/gevent/cares.pxd lib64/python2.7/site-packages/gevent/cares_ntop.h lib64/python2.7/site-packages/gevent/cares_pton.h lib64/python2.7/site-packages/gevent/core.py lib64/python2.7/site-packages/gevent/core.pyc lib64/python2.7/site-packages/gevent/dnshelper.c lib64/python2.7/site-packages/gevent/event.py lib64/python2.7/site-packages/gevent/event.pyc lib64/python2.7/site-packages/gevent/fileobject.py lib64/python2.7/site-packages/gevent/fileobject.pyc lib64/python2.7/site-packages/gevent/gevent._semaphore.c lib64/python2.7/site-packages/gevent/gevent.ares.c lib64/python2.7/site-packages/gevent/gevent.ares.h lib64/python2.7/site-packages/gevent/greenlet.py lib64/python2.7/site-packages/gevent/greenlet.pyc lib64/python2.7/site-packages/gevent/hub.py lib64/python2.7/site-packages/gevent/hub.pyc lib64/python2.7/site-packages/gevent/local.py lib64/python2.7/site-packages/gevent/local.pyc lib64/python2.7/site-packages/gevent/lock.py lib64/python2.7/site-packages/gevent/lock.pyc lib64/python2.7/site-packages/gevent/monkey.py lib64/python2.7/site-packages/gevent/monkey.pyc lib64/python2.7/site-packages/gevent/os.py lib64/python2.7/site-packages/gevent/os.pyc lib64/python2.7/site-packages/gevent/pool.py lib64/python2.7/site-packages/gevent/pool.pyc lib64/python2.7/site-packages/gevent/python.pxd lib64/python2.7/site-packages/gevent/pywsgi.py lib64/python2.7/site-packages/gevent/pywsgi.pyc lib64/python2.7/site-packages/gevent/queue.py lib64/python2.7/site-packages/gevent/queue.pyc lib64/python2.7/site-packages/gevent/resolver_ares.py lib64/python2.7/site-packages/gevent/resolver_ares.pyc lib64/python2.7/site-packages/gevent/resolver_thread.py lib64/python2.7/site-packages/gevent/resolver_thread.pyc lib64/python2.7/site-packages/gevent/select.py lib64/python2.7/site-packages/gevent/select.pyc lib64/python2.7/site-packages/gevent/server.py lib64/python2.7/site-packages/gevent/server.pyc lib64/python2.7/site-packages/gevent/signal.py lib64/python2.7/site-packages/gevent/signal.pyc lib64/python2.7/site-packages/gevent/socket.py lib64/python2.7/site-packages/gevent/socket.pyc lib64/python2.7/site-packages/gevent/ssl.py lib64/python2.7/site-packages/gevent/ssl.pyc lib64/python2.7/site-packages/gevent/subprocess.py lib64/python2.7/site-packages/gevent/subprocess.pyc lib64/python2.7/site-packages/gevent/thread.py lib64/python2.7/site-packages/gevent/thread.pyc lib64/python2.7/site-packages/gevent/threading.py lib64/python2.7/site-packages/gevent/threading.pyc lib64/python2.7/site-packages/gevent/threadpool.py lib64/python2.7/site-packages/gevent/threadpool.pyc lib64/python2.7/site-packages/gevent/timeout.py lib64/python2.7/site-packages/gevent/timeout.pyc lib64/python2.7/site-packages/gevent/util.py lib64/python2.7/site-packages/gevent/util.pyc lib64/python2.7/site-packages/gevent/win32util.py lib64/python2.7/site-packages/gevent/win32util.pyc lib64/python2.7/site-packages/gevent/wsgi.py lib64/python2.7/site-packages/gevent/wsgi.pyc /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le//opt/xcat/lib/python/agent/gevent
+ install -m755 lib64/python2.7/site-packages/gevent/libev/__init__.py lib64/python2.7/site-packages/gevent/libev/__init__.pyc lib64/python2.7/site-packages/gevent/libev/_corecffi.so lib64/python2.7/site-packages/gevent/libev/_corecffi_build.py lib64/python2.7/site-packages/gevent/libev/_corecffi_build.pyc lib64/python2.7/site-packages/gevent/libev/_corecffi_cdef.c lib64/python2.7/site-packages/gevent/libev/_corecffi_source.c lib64/python2.7/site-packages/gevent/libev/callbacks.c lib64/python2.7/site-packages/gevent/libev/callbacks.h lib64/python2.7/site-packages/gevent/libev/corecext.ppyx lib64/python2.7/site-packages/gevent/libev/corecext.pyx lib64/python2.7/site-packages/gevent/libev/corecext.so lib64/python2.7/site-packages/gevent/libev/corecffi.py lib64/python2.7/site-packages/gevent/libev/corecffi.pyc lib64/python2.7/site-packages/gevent/libev/gevent.corecext.c lib64/python2.7/site-packages/gevent/libev/libev.h lib64/python2.7/site-packages/gevent/libev/libev.pxd lib64/python2.7/site-packages/gevent/libev/libev_vfd.h lib64/python2.7/site-packages/gevent/libev/stathelper.c /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le//opt/xcat/lib/python/agent/gevent/libev
+ /usr/lib/rpm/find-debuginfo.sh --strict-build-id -m --run-dwz --dwz-low-mem-die-limit 10000000 --dwz-max-die-limit 50000000 /root/rpmbuild/BUILD/python-openbmc-dep
extracting debug info from /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le/opt/xcat/lib/python/agent/greenlet.so
extracting debug info from /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le/opt/xcat/lib/python/agent/gevent/ares.so
extracting debug info from /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le/opt/xcat/lib/python/agent/gevent/_semaphore.so
extracting debug info from /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le/opt/xcat/lib/python/agent/gevent/libev/corecext.so
extracting debug info from /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le/opt/xcat/lib/python/agent/gevent/libev/_corecffi.so
/usr/lib/rpm/sepdebugcrcfix: Updated 5 CRC32s, 0 CRC32s did match.
cpio: /tmp/pip-build-7QzTnQ/gevent: Cannot stat: No such file or directory
cpio: /tmp/pip-build-7QzTnQ/greenlet: Cannot stat: No such file or directory
0 blocks
+ '[' '%{buildarch}' = noarch ']'
+ QA_CHECK_RPATHS=1
+ case "${QA_CHECK_RPATHS:-}" in
+ /usr/lib/rpm/check-rpaths
+ /usr/lib/rpm/check-buildroot
+ /usr/lib/rpm/redhat/brp-compress
+ /usr/lib/rpm/redhat/brp-strip-static-archive /usr/bin/strip
+ /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 0
Compiling /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le/opt/xcat/lib/python/agent/gevent/_socket3.py ...
  File "/opt/xcat/lib/python/agent/gevent/_socket3.py", line 195
    def makefile(self, mode="r", buffering=None, *,
                                                  ^
SyntaxError: invalid syntax

+ /usr/lib/rpm/redhat/brp-python-hardlink
+ /usr/lib/rpm/redhat/brp-java-repack-jars
Processing files: python-openbmc-dep-1.0-snap201803090524.ppc64le
Provides: python-openbmc-dep = 1:1.0-snap201803090524 python-openbmc-dep(ppc-64) = 1:1.0-snap201803090524
Requires(interp): /bin/sh /bin/sh /bin/sh
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires(pre): /bin/sh
Requires(post): /bin/sh
Requires(preun): /bin/sh
Requires: libc.so.6()(64bit) libc.so.6(GLIBC_2.17)(64bit) libpthread.so.0()(64bit) libpthread.so.0(GLIBC_2.17)(64bit) libpython2.7.so.1.0()(64bit) librt.so.1()(64bit) rtld(GNU_HASH)
Processing files: python-openbmc-dep-debuginfo-1.0-snap201803090524.ppc64le
Provides: python-openbmc-dep-debuginfo = 1:1.0-snap201803090524 python-openbmc-dep-debuginfo(ppc-64) = 1:1.0-snap201803090524
Requires(rpmlib): rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1 rpmlib(CompressedFileNames) <= 3.0.4-1
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le
Wrote: /root/rpmbuild/RPMS/ppc64le/python-openbmc-dep-1.0-snap201803090524.ppc64le.rpm
Wrote: /root/rpmbuild/RPMS/ppc64le/python-openbmc-dep-debuginfo-1.0-snap201803090524.ppc64le.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.qOHxs1
+ umask 022
+ cd /root/rpmbuild/BUILD
+ cd python-openbmc-dep
+ rm -rf /root/rpmbuild/BUILDROOT/python-openbmc-dep-1.0-snap201803090524.ppc64le
+ exit 0
[root@boston02 ~]# rpm -qp --requires /root/rpmbuild/RPMS/ppc64le/python-openbmc-dep-1.0-snap201803090524.ppc64le.rpm
/bin/sh
/bin/sh
/bin/sh
libc.so.6()(64bit)
libc.so.6(GLIBC_2.17)(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.17)(64bit)
libpython2.7.so.1.0()(64bit)
librt.so.1()(64bit)
python-requests
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PartialHardlinkSets) <= 4.0.4-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rtld(GNU_HASH)
rpmlib(PayloadIsXz) <= 5.2-1
```