### PR TITLE
Rebuild ipmitool-xcat for Ubuntu20

### DIFF
--- a/ipmitool/Build-notes
+++ b/ipmitool/Build-notes
@@ -20,7 +20,7 @@ RPM Option #2 Use the manual steps listed below:
 DEB Option #1
 
 1) git clone https://github.com/xcat2/xcat-dep.git
-2) apt install dpkg-dev debhelper libssl-dev quilt
+2) apt install dpkg-dev debhelper libssl-dev quilt libreadline-dev
 3) cd xcat-dep/ipmitool
 4) ./make_deb.sh
 5) Will generate file ipmitool-xcat_<version>_<arch>.deb file in current directory

--- a/ipmitool/debian/changelog
+++ b/ipmitool/debian/changelog
@@ -1,3 +1,8 @@
+ipmitool-xcat (1.8.18-4) unstable; urgency=low
+  * Build with dependencies for either libssl1.0.0 or libssl1.1
+
+ -- gurevich <gurevich@us.ibm.com>  Thu, 22 Sep 2022 11:10:00 +0100
+
 ipmitool-xcat (1.8.18-3) unstable; urgency=low
   * Add security patch CVE-2020-5208
 

--- a/ipmitool/debian/control
+++ b/ipmitool/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.6.2.1
 
 Package: ipmitool-xcat
 Architecture: i386 amd64 ia64 ppc64el
-Depends: ${shlibs:Depends}, lsb-base
+Depends: libc6 (>= 2.15), libssl1.1 (>= 1.1.0) | libssl1.0.0 (>=1.0.0), lsb-base
 Suggests: openipmi
 Description: utility for IPMI control with kernel driver or LAN interface
  A utility for managing and configuring devices that support the


### PR DESCRIPTION
Rebuild `ipmitool-xcat` so that is can install on Ubuntu16, 18 and 20

Currently `debian/control` file uses `${shlibs:Depends}` to generate `Depends` statement.
As a result, `${shlibs:Depends}` expands into some shared libraries found on the OS used for building the package.

Currently `ipmitool-xcat` version `1.18.18-3`, contains:
```
root@c910f04x12v05:/xcat-core# dpkg -s ipmitool-xcat
Package: ipmitool-xcat
Status: install ok installed
Priority: optional
Section: utils
Installed-Size: 837
Maintainer: xCAT <xcat-user@lists.sourceforge.net>
Architecture: amd64
Version: 1.8.18-3
Depends: libc6 (>= 2.15), libssl1.0.0 (>= 1.0.0), lsb-base
Suggests: openipmi
```
* The `ipmitool-xcat` can be installed on Ubuntu16, it has `libssl1.0.0` installed, which meets the required dependency:
   ```
   root@c910f04x12v05:~# apt list --installed | grep "libssl"
   libssl1.0.0/xenial-security,xenial-updates,now 1.0.2g-1ubuntu4.20 amd64 [installed]
   root@c910f04x12v05:~#
   ```
* The `ipmitool-xcat` can be installed on Ubuntu18, it has `libssl1.1` and `libssl1.0.0` installed, which meets the required dependency. *This is very strange as it seems to be treated as 2 different packages, not 2 versions of the same package*:
   ```
   root@c910f04x12v05:/xcat-core# apt list --installed | grep "libssl"
   libssl1.0.0/bionic-updates,bionic-security,now 1.0.2n-1ubuntu5.10 amd64 [installed]
   libssl1.1/bionic-updates,bionic-security,now 1.1.1-1ubuntu2.1~18.04.20 amd64 [installed]
   root@c910f04x12v05:/xcat-core#
   ```
* The `ipmitool-xcat` can **not** be installed on Ubuntu20, it only has `libssl1.1` installed. But `libssl1.0.0` is not installed, which does not meet the required dependency:
   ```
   root@c910f04x12v07:/etc/apt# apt list --installed | grep "libssl"
   libssl1.1/focal-security,now 1.1.1f-1ubuntu2.16 amd64 [installed]
   root@c910f04x12v07:/etc/apt#

   root@c910f04x12v07:/etc/apt# apt install ipmitool-xcat
   Reading package lists... Done
   Building dependency tree
   Reading state information... Done
   :
   :
   The following packages have unmet dependencies:
    ipmitool-xcat : Depends: libssl1.0.0 (>= 1.0.0) but it is not installable
   E: Unable to correct problems, you have held broken packages.
   root@c910f04x12v07:/etc/apt#
   ```

This PR will generate a new `ipmitool-xcat` version `1.18.18-4`. It replaces `${shlibs:Depends}` with explicit definition of `libssl` using OR `|` operator. This way dependency is satisfied by either `libssl1.1` or `libssl1.0.0`.

```
root@c910f04x12v05:/tmp/xcat-dep/ipmitool# dpkg --info ipmitool-xcat_1.8.18-4_amd64.deb
 new Debian package, version 2.0.
 size 300976 bytes: control archive=984 bytes.
    1187 bytes,    24 lines      control
      61 bytes,     1 lines      md5sums
 Package: ipmitool-xcat
 Version: 1.8.18-4
 Architecture: amd64
 Maintainer: xCAT <xcat-user@lists.sourceforge.net>
 Installed-Size: 923
 Depends: libc6 (>= 2.15), libssl1.1 (>= 1.1.0) | libssl1.0.0 (>= 1.0.0), lsb-base
 Suggests: openipmi
```
## UT:
#### Ubuntu16:
```
root@c910f04x12v05:/tmp/xcat-dep/ipmitool# apt list --installed | grep "libssl"
libssl-dev/xenial-security,xenial-updates,now 1.0.2g-1ubuntu4.20 amd64 [installed]
libssl-doc/xenial-security,xenial-security,xenial-updates,xenial-updates,now 1.0.2g-1ubuntu4.20 all [installed,automatic]
libssl1.0.0/xenial-security,xenial-updates,now 1.0.2g-1ubuntu4.20 amd64 [installed]
root@c910f04x12v05:/tmp/xcat-dep/ipmitool#

root@c910f04x12v05:/tmp/xcat-dep/ipmitool# apt install /tmp/xcat-dep/ipmitool/ipmitool-xcat_1.8.18-4_amd64.deb
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'ipmitool-xcat' instead of '/tmp/xcat-dep/ipmitool/ipmitool-xcat_1.8.18-4_amd64.deb'
Suggested packages:
  openipmi
The following NEW packages will be installed:
  ipmitool-xcat
0 upgraded, 1 newly installed, 0 to remove and 68 not upgraded.
Need to get 0 B/290 kB of archives.
After this operation, 857 kB of additional disk space will be used.
Get:1 /tmp/xcat-dep/ipmitool/ipmitool-xcat_1.8.18-4_amd64.deb ipmitool-xcat amd64 1.8.18-4 [290 kB]
Selecting previously unselected package ipmitool-xcat.
(Reading database ... 91026 files and directories currently installed.)
Preparing to unpack .../ipmitool-xcat_1.8.18-4_amd64.deb ...
Unpacking ipmitool-xcat (1.8.18-4) ...
Setting up ipmitool-xcat (1.8.18-4) ...
root@c910f04x12v05:/tmp/xcat-dep/ipmitool#

root@c910f04x12v05:/tmp/xcat-dep/ipmitool# apt list --installed | grep "ipmitool"
ipmitool-xcat/now 1.8.18-4 amd64 [installed,local]
root@c910f04x12v05:/tmp/xcat-dep/ipmitool#
```

#### Ubuntu18:
```
root@c910f04x12v05:/tmp# apt list --installed | grep "libssl"
libssl-dev/bionic-updates,bionic-security,now 1.1.1-1ubuntu2.1~18.04.20 amd64 [installed]
libssl1.0.0/bionic-updates,bionic-security,now 1.0.2n-1ubuntu5.10 amd64 [installed]
libssl1.1/bionic-updates,bionic-security,now 1.1.1-1ubuntu2.1~18.04.20 amd64 [installed]
root@c910f04x12v05:/tmp#

root@c910f04x12v05:/tmp# apt install /tmp/xcat-dep/ipmitool/ipmitool-xcat_1.8.18-4_amd64.deb
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'ipmitool-xcat' instead of '/tmp/xcat-dep/ipmitool/ipmitool-xcat_1.8.18-4_amd64.deb'
Suggested packages:
  openipmi
The following NEW packages will be installed:
  ipmitool-xcat
0 upgraded, 1 newly installed, 0 to remove and 86 not upgraded.
Need to get 0 B/301 kB of archives.
After this operation, 945 kB of additional disk space will be used.
Get:1 /tmp/xcat-dep/ipmitool/ipmitool-xcat_1.8.18-4_amd64.deb ipmitool-xcat amd64 1.8.18-4 [301 kB]
Selecting previously unselected package ipmitool-xcat.
(Reading database ... 94506 files and directories currently installed.)
Preparing to unpack .../ipmitool-xcat_1.8.18-4_amd64.deb ...
Unpacking ipmitool-xcat (1.8.18-4) ...
Setting up ipmitool-xcat (1.8.18-4) ...
root@c910f04x12v05:/tmp#

root@c910f04x12v05:/tmp# apt list --installed | grep "ipmitool"
ipmitool-xcat/now 1.8.18-4 amd64 [installed,local]
root@c910f04x12v05:/tmp#
```

#### Ubuntu20:
```
root@c910f04x12v07:/tmp# apt list --installed | grep "libssl"
libssl1.1/focal-security,now 1.1.1f-1ubuntu2.16 amd64 [installed]
root@c910f04x12v07:/tmp#


root@c910f04x12v07:/tmp# apt install /tmp/ipmitool-xcat_1.8.18-4_amd64.deb
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'ipmitool-xcat' instead of '/tmp/ipmitool-xcat_1.8.18-4_amd64.deb'
Suggested packages:
  openipmi
The following NEW packages will be installed:
  ipmitool-xcat
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/301 kB of archives.
After this operation, 945 kB of additional disk space will be used.
Get:1 /tmp/ipmitool-xcat_1.8.18-4_amd64.deb ipmitool-xcat amd64 1.8.18-4 [301 kB]
Selecting previously unselected package ipmitool-xcat.
(Reading database ... 62135 files and directories currently installed.)
Preparing to unpack .../ipmitool-xcat_1.8.18-4_amd64.deb ...
Unpacking ipmitool-xcat (1.8.18-4) ...
Setting up ipmitool-xcat (1.8.18-4) ...
root@c910f04x12v07:/tmp#

root@c910f04x12v07:/tmp# apt list --installed | grep "ipmitool"
ipmitool-xcat/now 1.8.18-4 amd64 [installed,local]
root@c910f04x12v07:/tmp#
```