### PR TITLE
Update ipmitool-xcat RPM version number and build instructions for RH9

### DIFF
--- a/ipmitool/Build-notes
+++ b/ipmitool/Build-notes
@@ -1,6 +1,11 @@
 Build Notes
+ipmitool-xcat is architecture specific and needs to be built separately on x86_64 and ppc64le
 
 RPM Option #1 Run the script bldipmi.pl
+1) yum install openssl-devel rpm-build autoconf automake libtool ncurses-devel readline-devel
+2) Update "release" variable in "bldipmi.pl" if generating a new version of the RPM
+3) Run "./bldipmi.pl" which creates:
+     /tmp/build/<os>/<arch>/ipmitool-xcat-<version>.<arch>.rpm
 
 RPM Option #2 Use the manual steps listed below:
 

--- a/ipmitool/bldipmi.pl
+++ b/ipmitool/bldipmi.pl
@@ -1,7 +1,7 @@
 #! /usr/bin/perl
 
 my $version = "1.8.18";
-my $release = "3";
+my $release = "4";
 
 #check the distro
 $cmd = "cat /etc/*release";

--- a/perl-HTML-Form/Build-notes
+++ b/perl-HTML-Form/Build-notes
@@ -4,4 +4,5 @@
 3. Run "rpmbuild -ba /usr/src/packages/SPECS/perl-HTML-Form.spec" which creates /usr/src/packages/RPMS/noarch/perl-HTML-Form-6.03-5.1.noarch.rpm
 
 For RHEL 8, run "rpmbuild --rebuild perl-HTML-Form-6.03-19.fc29.src.rpm".
-For RHEL 9, run "rpmbuild --rebuild perl-HTML-Form-6.07-4.fc34.src.rpm".
+For RHEL 9, run "yum install perl-HTML-Parser" 
+                "rpmbuild --rebuild perl-HTML-Form-6.07-4.fc34.src.rpm".

--- a/perl-IO-Stty/Build-notes
+++ b/perl-IO-Stty/Build-notes
@@ -9,4 +9,6 @@ Build Notes
 7. rpmbuild -ta  /usr/src/packages/SOURCES/IO-Stty-.02.tar.gz
 
 For RHEL 8, run "rpmbuild --rebuild perl-IO-Stty-0.03-21.fc29.src.rpm".
-For RHEL 9, run "rpmbuild --rebuild perl-IO-Stty-0.04-5.fc34.src.rpm".
+For RHEL 9, run "dnf config-manager --set-enabled crb"
+                "dnf install perl-Pod-Coverage OpenIPMI-devel nasm golang gnu-efi gnu-efi-devel"
+                "rpmbuild --rebuild perl-IO-Stty-0.04-5.fc34.src.rpm".


### PR DESCRIPTION
Continuing work of #52 
* Bump up `ipmitool-xcat` "release" number in build script to match the `.spec` file.
* Update some RPMs build notes for building on RH9