### PR TITLE
fix(ipmitool,conserver): OpenSSL 3 compatibility for SLES 15 / Leap 15

### DIFF
--- a/conserver/conserver.spec
+++ b/conserver/conserver.spec
@@ -22,6 +22,7 @@ Group: System Environment/Daemons
 URL: http://www.conserver.com/
 Source: http://www.conserver.com/%{pkg}-%{ver}.tar.gz
 Patch: initscript_8.2.1.patch
+Patch1: openssl3-dh-opaque.patch
 BuildRoot: %{_tmppath}/%{pkg}-buildroot
 BuildRequires: openssl-devel
 Prefix: %{_prefix}
@@ -40,6 +41,7 @@ bells and whistles to accentuate that basic functionality.
 %{__rm} -rf %{buildroot}
 %setup -n %{pkg}-%{ver}
 %patch -p1
+%patch1 -p1
 
 
 %build

--- a/conserver/openssl3-dh-opaque.patch
+++ b/conserver/openssl3-dh-opaque.patch
@@ -1,0 +1,106 @@
+--- a/conserver/main.c	2026-05-11 12:58:13
++++ b/conserver/main.c	2026-05-11 13:01:10
+@@ -112,12 +112,25 @@
+ 
+     if ((dh = DH_new()) == NULL)
+ 	return (NULL);
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L  /* OpenSSL >= 1.1.0 */
++    {
++	BIGNUM *p = BN_bin2bn(dh512_p, sizeof(dh512_p), NULL);
++	BIGNUM *g = BN_bin2bn(dh512_g, sizeof(dh512_g), NULL);
++	if (p == NULL || g == NULL || !DH_set0_pqg(dh, p, NULL, g)) {
++	    BN_free(p);
++	    BN_free(g);
++	    DH_free(dh);
++	    return (NULL);
++	}
++    }
++#else
+     dh->p = BN_bin2bn(dh512_p, sizeof(dh512_p), NULL);
+     dh->g = BN_bin2bn(dh512_g, sizeof(dh512_g), NULL);
+     if ((dh->p == NULL) || (dh->g == NULL)) {
+ 	DH_free(dh);
+ 	return (NULL);
+     }
++#endif
+     return (dh);
+ }
+ 
+@@ -146,12 +159,25 @@
+ 
+     if ((dh = DH_new()) == NULL)
+ 	return (NULL);
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L  /* OpenSSL >= 1.1.0 */
++    {
++	BIGNUM *p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL);
++	BIGNUM *g = BN_bin2bn(dh1024_g, sizeof(dh1024_g), NULL);
++	if (p == NULL || g == NULL || !DH_set0_pqg(dh, p, NULL, g)) {
++	    BN_free(p);
++	    BN_free(g);
++	    DH_free(dh);
++	    return (NULL);
++	}
++    }
++#else
+     dh->p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL);
+     dh->g = BN_bin2bn(dh1024_g, sizeof(dh1024_g), NULL);
+     if ((dh->p == NULL) || (dh->g == NULL)) {
+ 	DH_free(dh);
+ 	return (NULL);
+     }
++#endif
+     return (dh);
+ }
+ 
+@@ -193,12 +219,25 @@
+ 
+     if ((dh = DH_new()) == NULL)
+ 	return (NULL);
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L  /* OpenSSL >= 1.1.0 */
++    {
++	BIGNUM *p = BN_bin2bn(dh2048_p, sizeof(dh2048_p), NULL);
++	BIGNUM *g = BN_bin2bn(dh2048_g, sizeof(dh2048_g), NULL);
++	if (p == NULL || g == NULL || !DH_set0_pqg(dh, p, NULL, g)) {
++	    BN_free(p);
++	    BN_free(g);
++	    DH_free(dh);
++	    return (NULL);
++	}
++    }
++#else
+     dh->p = BN_bin2bn(dh2048_p, sizeof(dh2048_p), NULL);
+     dh->g = BN_bin2bn(dh2048_g, sizeof(dh2048_g), NULL);
+     if ((dh->p == NULL) || (dh->g == NULL)) {
+ 	DH_free(dh);
+ 	return (NULL);
+     }
++#endif
+     return (dh);
+ }
+ 
+@@ -266,12 +305,25 @@
+ 
+     if ((dh = DH_new()) == NULL)
+ 	return (NULL);
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L  /* OpenSSL >= 1.1.0 */
++    {
++	BIGNUM *p = BN_bin2bn(dh4096_p, sizeof(dh4096_p), NULL);
++	BIGNUM *g = BN_bin2bn(dh4096_g, sizeof(dh4096_g), NULL);
++	if (p == NULL || g == NULL || !DH_set0_pqg(dh, p, NULL, g)) {
++	    BN_free(p);
++	    BN_free(g);
++	    DH_free(dh);
++	    return (NULL);
++	}
++    }
++#else
+     dh->p = BN_bin2bn(dh4096_p, sizeof(dh4096_p), NULL);
+     dh->g = BN_bin2bn(dh4096_g, sizeof(dh4096_g), NULL);
+     if ((dh->p == NULL) || (dh->g == NULL)) {
+ 	DH_free(dh);
+ 	return (NULL);
+     }
++#endif
+     return (dh);
+ }
+ 

--- a/ipmitool/0017-openssl3-disable-md2-without-header.patch
+++ b/ipmitool/0017-openssl3-disable-md2-without-header.patch
@@ -1,5 +1,5 @@
---- ipmitool-1.8.18.orig/configure.ac	2026-05-11 11:35:37
-+++ ipmitool-1.8.18/configure.ac	2026-05-11 11:36:20
+--- a/configure.ac	2026-05-11 11:35:37
++++ b/configure.ac	2026-05-11 11:36:20
 @@ -184,9 +184,12 @@
  	[if test "x$xenable_internal_md5" != "xyes"; then
  	    if test "x$have_crypto" != "xyes" && test "x$have_md5" != "xyes"; then

--- a/ipmitool/0017-openssl3-disable-md2-without-header.patch
+++ b/ipmitool/0017-openssl3-disable-md2-without-header.patch
@@ -1,0 +1,16 @@
+--- ipmitool-1.8.18.orig/configure.ac	2026-05-11 11:35:37
++++ ipmitool-1.8.18/configure.ac	2026-05-11 11:36:20
+@@ -184,9 +184,12 @@
+ 	[if test "x$xenable_internal_md5" != "xyes"; then
+ 	    if test "x$have_crypto" != "xyes" && test "x$have_md5" != "xyes"; then
+ 	        LIBS="$LIBS -lcrypto"
+-	        have_md2=yes
+ 	    fi
+-	    AC_DEFINE(HAVE_CRYPTO_MD2, [1], [Define to 1 if libcrypto supports MD2.])
++	    AC_CHECK_HEADER([openssl/md2.h],
++	        [have_md2=yes
++	         AC_DEFINE(HAVE_CRYPTO_MD2, [1],
++	            [Define to 1 if libcrypto supports MD2.])],
++	        [have_md2=no])
+ 	fi],
+ 	[], [-lcrypto])

--- a/ipmitool/ipmitool.spec
+++ b/ipmitool/ipmitool.spec
@@ -25,6 +25,8 @@ Patch14:      0014-lanplus-cipher-retry.patch
 Patch15:      0015-lanplus-Cleanup.-Refix-6dec83ff-fix-be2c0c4b.patch
 Patch16:      0016-el10-gcc14-missing-intf-getters.patch
 
+Patch17:      0017-openssl3-disable-md2-without-header.patch
+
 Patch80:      ipmitool-%{version}-saneretry.patch
 Patch82:      ipmitool-%{version}-rflash.patch
 Patch83:      ipmitool-%{version}-signal.patch
@@ -75,6 +77,7 @@ fi
 %patch14  -p1
 %patch15  -p1
 %patch16  -p1
+%patch17  -p1
 %patch80 -p1
 %patch82 -p1
 %patch83 -p1


### PR DESCRIPTION
This one addresses more issues related to OpenSSL 3.0:

- **ipmitool**: `configure.ac` checks for `MD2_Init` in libcrypto but not for `<openssl/md2.h>`. On OpenSSL 3.x the symbol exists as a deprecated shim but the header is removed, causing `HAVE_CRYPTO_MD2` to be set and compilation to fail. Add `AC_CHECK_HEADER` for the header inside the existing `AC_CHECK_LIB` block.

- **conserver**: OpenSSL 3.x made the `DH` struct opaque — direct `dh->p` / `dh->g` member access no longer compiles. Replace with `DH_set0_pqg()` behind `#if OPENSSL_VERSION_NUMBER >= 0x10100000L` so older OpenSSL keeps the original code path.

## Validation

- RPM build on SLES 15 SP7 (x86_64 + ppc64le): PASS
- RPM build on Leap 15.6 (x86_64 + ppc64le): PASS
- Install + xCAT functional test on KVM lab: both architectures verified

## Backward compatibility

- ipmitool: on OpenSSL < 3.x where both symbol and header exist, MD2 is still enabled — no behavior change
- conserver: `#if OPENSSL_VERSION_NUMBER >= 0x10100000L` preserves the old direct-access code for OpenSSL < 1.1.0