### PR TITLE
Fixes for xCAT 2.18 release - Ubuntu (noble)

### DIFF
--- a/build-apt-repo.sh
+++ b/build-apt-repo.sh
@@ -20,11 +20,24 @@ declare -A CODENAME_MAP=(
 )
 ARCHITECTURES=(amd64 ppc64el)
 
+# Versions to build. Populated from positional DIST args; defaults to all of
+# CODENAME_MAP when none are given. SUBSET=1 means the user requested a subset
+# (so cleanup is scoped to the selected dists instead of wiping the whole repo).
+SELECTED_VERS=()
+SUBSET=0
+
 usage() {
     cat <<'EOF'
-Usage: build-apt-repo.sh [options]
+Usage: build-apt-repo.sh [options] [DIST ...]
 
 Generate APT repository metadata from pre-built .deb packages.
+
+Arguments:
+  DIST ...               One or more Ubuntu versions to build, e.g. ubuntu24.04.
+                         Valid values: ubuntu22.04 ubuntu24.04 ubuntu26.04.
+                         When omitted, all three are built (default behavior).
+                         Building a subset only touches those dists; other
+                         existing dists in the repo are left untouched.
 
 Options:
   --repo-root PATH       xcat-dep repository root (default: script directory)
@@ -33,6 +46,10 @@ Options:
   --skip-sign            Skip GPG signing (for testing)
   --dry-run              Print planned actions without executing
   -h, --help             Show this help
+
+Examples:
+  build-apt-repo.sh                 # build all dists (default)
+  build-apt-repo.sh ubuntu24.04     # build only noble
 EOF
 }
 
@@ -55,12 +72,25 @@ while [[ $# -gt 0 ]]; do
         --skip-sign)   SKIP_SIGN=1; shift ;;
         --dry-run)     DRY_RUN=1; shift ;;
         -h|--help)     usage; exit 0 ;;
-        *)             die "Unknown option: $1" ;;
+        -*)            die "Unknown option: $1" ;;
+        *)             SELECTED_VERS+=("$1"); SUBSET=1; shift ;;
     esac
 done
 
 REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
 APT_DIR="${APT_DIR:-$REPO_ROOT/repos/apt}"
+
+# Default to all known versions when no DIST arg was given; otherwise validate
+# each requested version against CODENAME_MAP.
+if [[ ${#SELECTED_VERS[@]} -eq 0 ]]; then
+    SELECTED_VERS=("${!CODENAME_MAP[@]}")
+else
+    for ver in "${SELECTED_VERS[@]}"; do
+        [[ -n "${CODENAME_MAP[$ver]:-}" ]] \
+            || die "Unknown DIST '$ver'. Valid: ${!CODENAME_MAP[*]}"
+    done
+fi
+echo "Building dists: ${SELECTED_VERS[*]}"
 
 step "Validating prerequisites"
 
@@ -78,7 +108,7 @@ else
     echo "GPG signing: skipped"
 fi
 
-for ver in "${!CODENAME_MAP[@]}"; do
+for ver in "${SELECTED_VERS[@]}"; do
     src="$APT_DIR/$ver"
     [[ -d "$src" ]] || die "Source directory missing: $src"
     count=$(find "$src" -maxdepth 1 -name '*.deb' | wc -l)
@@ -89,13 +119,22 @@ done
 step "Cleaning previous repo metadata"
 
 if [[ $DRY_RUN -eq 0 ]]; then
-    rm -rf "$APT_DIR/dists" "$APT_DIR/pool"
+    if [[ $SUBSET -eq 1 ]]; then
+        # Subset build: only remove the selected dists, leave others intact.
+        for ver in "${SELECTED_VERS[@]}"; do
+            codename="${CODENAME_MAP[$ver]}"
+            rm -rf "$APT_DIR/dists/$codename" "$APT_DIR/pool/main/$codename"
+        done
+        echo "Removed dists/ and pool/ for: ${SELECTED_VERS[*]}"
+    else
+        rm -rf "$APT_DIR/dists" "$APT_DIR/pool"
+        echo "Removed dists/ and pool/"
+    fi
 fi
-echo "Removed dists/ and pool/"
 
 step "Creating directory structure"
 
-for ver in "${!CODENAME_MAP[@]}"; do
+for ver in "${SELECTED_VERS[@]}"; do
     codename="${CODENAME_MAP[$ver]}"
     run mkdir -p "$APT_DIR/pool/main/$codename"
     for arch in "${ARCHITECTURES[@]}"; do
@@ -105,7 +144,7 @@ done
 
 step "Populating pool"
 
-for ver in "${!CODENAME_MAP[@]}"; do
+for ver in "${SELECTED_VERS[@]}"; do
     codename="${CODENAME_MAP[$ver]}"
     src="$APT_DIR/$ver"
     dst="$APT_DIR/pool/main/$codename"
@@ -119,7 +158,7 @@ done
 
 step "Generating Packages indexes"
 
-for ver in "${!CODENAME_MAP[@]}"; do
+for ver in "${SELECTED_VERS[@]}"; do
     codename="${CODENAME_MAP[$ver]}"
     echo "Indexing $codename..."
 
@@ -160,7 +199,7 @@ done
 
 step "Generating Release files"
 
-for ver in "${!CODENAME_MAP[@]}"; do
+for ver in "${SELECTED_VERS[@]}"; do
     codename="${CODENAME_MAP[$ver]}"
     echo "Release for $codename..."
 
@@ -189,7 +228,7 @@ done
 if [[ $SKIP_SIGN -eq 0 ]]; then
     step "Signing Release files"
 
-    for ver in "${!CODENAME_MAP[@]}"; do
+    for ver in "${SELECTED_VERS[@]}"; do
         codename="${CODENAME_MAP[$ver]}"
         release="$APT_DIR/dists/$codename/Release"
 
@@ -214,9 +253,18 @@ key_src="$REPO_ROOT/repomd.xml.key"
 key_dst="$APT_DIR/xcat-dep.asc"
 if [[ -f "$key_src" ]]; then
     run cp "$key_src" "$key_dst"
-    echo "Public key -> xcat-dep.asc"
+    echo "Public key -> xcat-dep.asc (from $key_src)"
+elif [[ $DRY_RUN -eq 1 ]]; then
+    echo "(dry-run: would export $GPG_KEY_ID public key to xcat-dep.asc)"
 else
-    echo "WARNING: $key_src not found, skipping key export"
+    # No pre-exported key file: export the signing public key straight from the
+    # keyring (honors GNUPGHOME), so clients get the matching pubkey.
+    if gpg --armor --export "$GPG_KEY_ID" > "$key_dst" 2>/dev/null && [[ -s "$key_dst" ]]; then
+        echo "Public key -> xcat-dep.asc (exported $GPG_KEY_ID from keyring)"
+    else
+        rm -f "$key_dst"
+        echo "WARNING: could not export '$GPG_KEY_ID' and $key_src not found; no xcat-dep.asc written"
+    fi
 fi
 
 step "Summary"

--- a/build-debs-all
+++ b/build-debs-all
@@ -59,6 +59,7 @@ echo "prepare building gensis_base_amd64 as a special case"
 #copy the debian_dir and rpm for xcat-genesia-base to the tem directory
 mkdir -p $curdir/genesis_tmp/genesis-base-amd64
 cp -rL ${1}/debian $curdir/genesis_tmp/genesis-base-amd64
+cp -L ${1}/LICENSE.html $curdir/genesis_tmp/genesis-base-amd64
 cp ${2} $curdir/genesis_tmp/genesis-base-amd64
 cd $curdir
 cat << __EOF__ > genesis_tmp/make_deb.sh
@@ -70,7 +71,7 @@ cat << __EOF__ > genesis_tmp/make_deb.sh
 __EOF__
 
 #update to the loatest code
-svn --quiet update
+# svn --quiet update
 packages=""
 if [ $BUILDPKGS ];then
     packages=$BUILDPKGS

--- a/goconserver/debian/rules
+++ b/goconserver/debian/rules
@@ -10,6 +10,7 @@ override_dh_auto_install:
 	install -D -m 755 goconserver $(CURDIR)/debian/goconserver/usr/bin/goconserver
 	install -D -m 755 congo $(CURDIR)/debian/goconserver/usr/bin/congo
 	install -D -m 644 etc/goconserver/server.conf $(CURDIR)/debian/goconserver/etc/goconserver/server.conf
+	install -D -m 644 etc/systemd/goconserver.service $(CURDIR)/debian/goconserver/lib/systemd/system/goconserver.service
 	mkdir -p $(CURDIR)/debian/goconserver/var/log/goconserver
 	mkdir -p $(CURDIR)/debian/goconserver/var/lib/goconserver
 override_dh_auto_test:

--- a/goconserver/make_deb.sh
+++ b/goconserver/make_deb.sh
@@ -37,6 +37,11 @@ export GOMODCACHE="$WORKDIR/gomodcache"
 export CGO_ENABLED=0
 
 go mod init github.com/xcat2/goconserver
+# kr/pty is abandoned and its pty.Start sets Ctty in a way Go >=1.15 rejects
+# ("Setctty set but Ctty not valid in child"), breaking rcons/goconserver on
+# modern Go (noble ships go1.22). creack/pty is the maintained, API-compatible
+# fork that fixes it.
+go mod edit -replace github.com/kr/pty=github.com/creack/pty@v1.1.21
 go mod tidy
 
 cp -rL "$SCRIPT_DIR/debian" .


### PR DESCRIPTION
## Ubuntu 24.04 (noble) support: dependency packaging + console fixes

This PR collects the xcat-dep fixes needed to build the Ubuntu 24.04 (noble) dependency packages and assemble a signed apt repo for them, and to make the goconserver console work on a modern Ubuntu toolchain. Companion product fixes are in xcat2/xcat-core (#7578).

### How this was validated

These were exercised end-to-end while bringing up an Ubuntu 24.04 (noble) xCAT management node from the resulting packages: the dep packages build, the noble apt repo assembles and signs, the genesis-base deb builds, `apt install xcat` succeeds, `makegocons` succeeds, and `rcons` attaches to a node's serial console with live output.

### Fixes

**Build tooling**
- **build-debs-all: stage LICENSE.html for the genesis-base package build** — building the genesis-base deb failed at `dh_installdocs` because `LICENSE.html` could not be found: only the `debian/` directory and the source RPM were copied into the build root, while `debian/docs` references `LICENSE.html`. Copy `LICENSE.html` into the build root alongside `debian/`. Also drop the dead `svn update` call left over from the pre-git build.
- **build-apt-repo: support single-distribution builds and export the key** — the repository generator always iterated every supported distribution and aborted if any one had no packages, so it could not assemble a repo for a single release. It also only published a pre-exported key file and warned when that file was absent. Accept optional distribution arguments to build a subset (e.g. just noble), and export the signing public key from the keyring when no pre-exported key file exists.

**Console (goconserver)**
- **goconserver: install the systemd service unit in the package** — the goconserver deb shipped no systemd unit, so enabling or starting the goconserver service after installation had nothing to start (`makegocons` failed with "Failed to start goconserver service"). Install the provided `goconserver.service` unit during packaging.
- **goconserver: build against creack/pty for modern Go compatibility** — goconserver imports the abandoned `kr/pty`, whose `pty.Start` sets the controlling tty in a way Go >= 1.15 rejects ("fork/exec ...: Setctty set but Ctty not valid in child"). On current toolchains this breaks the console backend: `rcons` connects but the session produces no output. Replace `kr/pty` with the maintained, API-compatible `creack/pty` fork at build time.