### PR TITLE
Build the Ubuntu dependency packages for riscv64

### DIFF
--- a/.github/workflows/genesis-openembedded.yml
+++ b/.github/workflows/genesis-openembedded.yml
@@ -55,5 +55,6 @@ jobs:
       - name: Run package tests
         run: |
           prove -v t/build_utils.t
+          prove -v t/build_timeout.t
           prove -v -It/lib t/genesis_openembedded_release.t
           sudo -E prove -v -It/lib t/genesis_openembedded_consumer.t

--- a/.github/workflows/genesis-openembedded.yml
+++ b/.github/workflows/genesis-openembedded.yml
@@ -56,5 +56,6 @@ jobs:
         run: |
           prove -v t/build_utils.t
           prove -v t/build_timeout.t
+          prove -v t/sbuild-all.t
           prove -v -It/lib t/genesis_openembedded_release.t
           sudo -E prove -v -It/lib t/genesis_openembedded_consumer.t

--- a/BUILD.md
+++ b/BUILD.md
@@ -265,7 +265,7 @@ The APT side takes the same option, on the run that **publishes**:
 
 ```bash
 ./sbuild-all.pl --skip-build --skip-genesis \
-  --publish --expect-arch "amd64 ppc64el" \
+  --publish --expect-arch "amd64 ppc64el riscv64" \
   --genesis-release /path/to/xcat-genesis-release \
   --gpg-sign --gpg-key-id <id> --gpg-home <gpg-home>
 ```
@@ -678,7 +678,7 @@ the two hosts can run at the same time. `--dists` may be omitted entirely — wi
 
 ```bash
 ./sbuild-all.pl --skip-build --skip-genesis \
-  --publish --expect-arch "amd64 ppc64el" \
+  --publish --expect-arch "amd64 ppc64el riscv64" \
   --gpg-sign --gpg-key-id xcat@example.com --gpg-home <gpg-home>
 ```
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -586,9 +586,8 @@ Codename ↔ version (the single supported set — `BuildUtils` is the source of
 - **Fresh staging + promote-on-success.** Everything is built + validated into a per-run staging tree
   first; the published apt repo is (re)assembled from staging ONLY after the complete expected set
   validates — a partial/failed build never reaches the repo and stale debs never accumulate.
-- **Build runs stage; publishing is a separate, locked, atomic step.** The two arches build
-  *concurrently* on their two hosts against the same `--apt-dir`, so an arch build run **never
-  publishes**: it fills staging and stops. Publishing happens with **`--publish`** (implied by
+- **Build runs stage; publishing is a separate, locked, atomic step.** The arches build
+  *concurrently* against the same `--apt-dir`, so an arch build run **never publishes**: it fills staging and stops. Publishing happens with **`--publish`** (implied by
   `--skip-build`, i.e. the finalization run). That step takes **one global publish lock** — not the
   per-arch build lock — assembles the whole tree into a **side directory**, runs the repo gate against
   *that* tree, and only then swaps it onto `--apt-dir` with a single `rename(2)`. Readers therefore
@@ -609,8 +608,10 @@ Codename ↔ version (the single supported set — `BuildUtils` is the source of
   arch's `Packages` index. They are listed for **ppc64el too, as required-present**, so the gate
   verifies the ppc repo actually carries them (a ppc MN needs them for netboot, matching the EL
   manifest). `build_one_codename` **skips** an `Architecture:all` package on any non-amd64 arch
-  (detected via `control_binary_arch`), so ppc builds only the genuinely arch-specific compiled deps
-  (`ipmitool-xcat`, `conserver-xcat`, `goconserver`) yet still verifies the boot components.
+  (detected via `control_binary_arch`), so ppc64el and riscv64 build only the genuinely
+  arch-specific compiled deps (`ipmitool-xcat`, `conserver-xcat`, `goconserver`) yet still verify the
+  boot components they need. The riscv64 sections require `grub2-xcat` only: the x86 loaders
+  (`syslinux-xcat`, `elilo-xcat`, `xnba-undi`) are not part of a riscv64 repository.
 - **Fail-hard.** Any required chroot / package / artifact failure, or any version-pin mismatch, fails
   the whole run non-zero.
 - **Genesis keeps its maintained packaging.** A native `xcat-genesis-base` deb is INGESTED as-is when
@@ -623,7 +624,7 @@ Codename ↔ version (the single supported set — `BuildUtils` is the source of
 ## Files
 
 - **`sbuild-all.pl`** — the orchestrator (run as **root** on the Ubuntu build host: the amd64 host for
-  `amd64`, the ppc host for `ppc64el`).
+  `amd64` and, through qemu-user, for `riscv64`; the ppc host for `ppc64el`).
 - **`BuildUtils.pm`** — shared, unit-tested helpers + the canonical CLI spec (mirrors `MockBuildUtils.pm`).
 - **`<dep>/sbuild.pl`** ×7 — per-package builders (mirror `<dep>/mockbuild.pl`); each drives its
   maintained `debian/` in the chroot and collects the `.deb`(s). Invoked by `sbuild-all.pl`.
@@ -647,6 +648,49 @@ probe is what asserts it is usable.
 
 The per-codename sbuild chroots are separate host state — see `ci/mk-dep-chroots.sh`.
 
+## riscv64: cross-building on an amd64 host
+
+There is no riscv64 Ubuntu build host in the xCAT build farm, so the riscv64 packages are
+cross-built on the amd64 host. `sbuild-all.pl` bootstraps a riscv64 `schroot` with
+`debootstrap --arch=riscv64`, and every command inside it -- debootstrap's second stage,
+`apt-get`, `dpkg-buildpackage` -- runs through the `qemu-riscv64` binfmt handler, so each package
+is compiled by the chroot's own riscv64 toolchain.
+
+`--install-deps` installs `qemu-user-static` and `binfmt-support` with the rest of the toolchain.
+Confirm the handler before the first riscv64 run:
+
+```bash
+cat /proc/sys/fs/binfmt_misc/qemu-riscv64        # enabled, flags: POF
+```
+
+The `F` flag is what makes the handler usable from a chroot: the kernel opens the interpreter when
+the handler is registered, so the static QEMU binary does not have to exist under the chroot root.
+Without a registered handler `sbuild-all.pl` refuses to create the chroot and names the handler and
+the packages that provide it, instead of failing deep inside debootstrap.
+
+`archive.ubuntu.com` carries amd64 and i386 only; every other architecture is on
+`ports.ubuntu.com/ubuntu-ports`. The bootstrap mirror is defaulted from `--arch`, so a riscv64 run
+needs no `--mirror`.
+
+| what | how |
+|---|---|
+| ipmitool-xcat, conserver-xcat | `dpkg-buildpackage` in the emulated riscv64 chroot |
+| goconserver | same chroot, compiled by the Go toolchain the chroot installs for riscv64 |
+| grub2-xcat (`Architecture:all`) | built once on amd64 and assembled into the riscv64 index; listed in the riscv64 manifest sections as required-present, because a riscv64 management node needs it to netboot |
+| syslinux-xcat, elilo-xcat, xnba-undi | not built and not required (x86 loaders) |
+| xcat-genesis-base | not built: no riscv64 section names it, and the build skips the step when the manifest does not ask for it, so `--skip-genesis` is unnecessary here |
+
+The riscv64 ipmitool-xcat deb is installed into the chroot that built it and
+`/opt/xcat/bin/ipmitool-xcat -V` runs there before the run is called good. A cross-built binary
+links against the target's loader and libraries, so the chroot is the only place it can run at all,
+and without that check a deb whose binary never executes still builds green.
+
+Emulated builds are slow. On an 8-core amd64 host, bootstrapping the noble riscv64 chroot took
+about 4 minutes and ipmitool-xcat about 12, against seconds natively, so plan a riscv64 run of the
+whole dependency set in hours rather than minutes. `--build-timeout` sets the per-package
+wall-clock bound. A build that deadlocks under qemu-user is killed with a stall report rather than
+hanging the pipeline, which is what goconserver did.
+
 ## Usage (per arch, as root on the matching build host)
 
 Run `sbuild-all.pl` on the build host for the arch you are building (amd64 on the x86 Ubuntu host,
@@ -668,10 +712,15 @@ finalization step publishes the assembled repo atomically.
 # ppc64el host — arch-specific deps only (the Architecture:all boot components and both genesis
 # debs come from the amd64 build):
 ./sbuild-all.pl --arch ppc64el --dists "focal jammy noble resolute" --skip-genesis
+
+# riscv64 — cross-built on the amd64 host (there is no riscv64 build host); arch-specific deps
+# only, and the genesis step is skipped by the manifest rather than by a flag:
+./sbuild-all.pl --arch riscv64 --dists "focal jammy noble resolute"
 ```
 
 These runs touch **only** `staging/<codename>/<arch>/`; the apt tree at `--apt-dir` is left alone, so
-the two hosts can run at the same time. `--dists` may be omitted entirely — with no
+they can run at the same time. The build lock is per arch, so the amd64 and riscv64 runs can share
+one host. `--dists` may be omitted entirely — with no
 `--dists`/`--target`, **all supported codenames** are built (`focal jammy noble resolute`).
 
 ### Step 2 — publish once, after every arch has staged

--- a/BuildUtils.pm
+++ b/BuildUtils.pm
@@ -15,7 +15,9 @@ package BuildUtils;
 use strict;
 use warnings;
 use Exporter 'import';
-use File::Basename qw(basename);
+use File::Basename qw(basename dirname);
+use lib dirname(__FILE__) . '/lib';
+use XCAT::BuildUtils qw(run_bounded emulated_build_timeout);
 use File::Copy qw(copy);
 use File::Path qw(make_path);
 use Digest::MD5;
@@ -31,6 +33,7 @@ our @EXPORT_OK = qw(
     codename_to_version version_to_codename known_codenames
     supported_arches is_supported_arch
     chroot_name chroot_sources_list chroot_is_disposable chroot_build_script
+    chroot_build_timeout
     control_field genesis_deb_control
     deb_field deb_version deb_hash cross_copy_genesis_deb
     build_deb_in_chroot
@@ -730,6 +733,20 @@ INNER
 # make_deb.sh); $build runs with CWD = the copied package dir and must leave its .deb(s) somewhere
 # under the build work tree. Dies on any failure -- including a chroot that is not disposable.
 #   %args: pkg, chroot, pkg_dir, result_dir, build_timestamp, build (required); extra_tools (arrayref, optional)
+# chroot_build_timeout($chroot): the wall-clock budget for one build in $chroot. The chroot is named
+# <codename>-<arch>-sbuild, so its arch says whether the build is native or runs through qemu-user.
+# XCAT_DEP_BUILD_TIMEOUT overrides it; sbuild-all.pl --build-timeout sets that variable, because the
+# per-package <dep>/sbuild.pl builders are separate processes with their own CLI. 0 disables the bound.
+sub chroot_build_timeout {
+    my ($chroot) = @_;
+    return int($ENV{XCAT_DEP_BUILD_TIMEOUT}) if defined $ENV{XCAT_DEP_BUILD_TIMEOUT}
+                                             && $ENV{XCAT_DEP_BUILD_TIMEOUT} =~ /^\d+$/;
+    my ($target_arch) = (($chroot // '') =~ /^.+-([^-]+)-sbuild$/);
+    my $host_arch = `dpkg --print-architecture 2>/dev/null`;
+    chomp $host_arch;
+    return emulated_build_timeout($target_arch, $host_arch);
+}
+
 sub build_deb_in_chroot {
     my (%a) = @_;
     defined $a{$_} or die "build_deb_in_chroot: missing '$_'\n"
@@ -760,8 +777,16 @@ sub build_deb_in_chroot {
             . sh_quote($a{pkg_dir}) . ' ' . sh_quote($a{result_dir}) . ' '
             . sh_quote($a{build_timestamp}) . ' ' . sh_quote($extra) . ' ' . sh_quote($b64);
     print "[$pkg] building in chroot $a{chroot} -> $a{result_dir} (SOURCE_DATE_EPOCH=$a{build_timestamp})\n";
-    my $rc = system('bash', '-c', $cmd);
-    my $ec = $rc == -1 ? -1 : ($rc >> 8);
+    # A build that deadlocks under qemu-user (a resolute goconserver `go build` did, with both Go
+    # pids in futex_wait and no CPU ticks at all) used to hang here forever, and a hung cell reads as
+    # "still running" rather than as a defect. Bound it, and print the process tree, each wchan and a
+    # CPU sample before the kill, so the failure says WHY it stopped.
+    my $timeout = defined $a{timeout} ? $a{timeout} : chroot_build_timeout($a{chroot});
+    my $r = run_bounded(cmd => $cmd, timeout => $timeout, label => "[$pkg] build in $a{chroot}",
+                        out => \*STDOUT);
+    die "[$pkg] build TIMED OUT after $r->{elapsed}s (budget ${timeout}s) -- see the stall report above\n"
+        if $r->{timed_out};
+    my $ec = $r->{ec};
     die "[$pkg] build failed (rc=$ec)\n" if $ec != 0;
     # The debs were copied from INSIDE the chroot; that only reaches the host if --result-dir is on a
     # bind-mounted path. Verify host-side so a mis-configured (chroot-local) result-dir fails LOUD.

--- a/BuildUtils.pm
+++ b/BuildUtils.pm
@@ -29,6 +29,7 @@ our @EXPORT_OK = qw(
     parse_packages_index parse_release_architectures resolve_present_names
     index_has_native_arch control_binary_arch skip_arch_all_on
     codename_to_version version_to_codename known_codenames
+    supported_arches is_supported_arch
     chroot_name chroot_sources_list chroot_is_disposable chroot_build_script
     control_field genesis_deb_control
     deb_field deb_version deb_hash cross_copy_genesis_deb
@@ -48,6 +49,17 @@ my %CODENAME_TO_VERSION = (
 my %VERSION_TO_CODENAME = reverse %CODENAME_TO_VERSION;
 
 sub known_codenames    { return sort keys %CODENAME_TO_VERSION; }
+
+# The dpkg architectures xcat-dep builds. amd64 is the native one and the single producer of the
+# Architecture:all packages; every other one is a secondary architecture, is served by
+# ubuntu-ports rather than archive.ubuntu.com, and is built through a qemu-user chroot when the
+# build host is amd64. Keep this the single source of truth: --arch, --target, --expect-arch and
+# the mirror choice all derive from it.
+my @ARCHES = qw(amd64 ppc64el riscv64);
+my %ARCH   = map { $_ => 1 } @ARCHES;
+
+sub supported_arches   { return @ARCHES; }
+sub is_supported_arch  { my ($a) = @_; return defined($a) && $ARCH{$a} ? 1 : 0; }
 sub codename_to_version { my ($c) = @_; return $CODENAME_TO_VERSION{$c // ''}; }
 sub version_to_codename { my ($v) = @_; return $VERSION_TO_CODENAME{$v // ''}; }
 

--- a/BuildUtils.pm
+++ b/BuildUtils.pm
@@ -801,8 +801,47 @@ sub build_deb_in_chroot {
     die "[$pkg] build succeeded in the chroot but no .deb is visible at $a{result_dir} on the host\n"
       . "  (is --result-dir on a path bind-mounted into the chroot, e.g. under /opt/xcat-ci-shared?)\n"
       unless @debs;
+    smoke_deb_in_chroot(%a, debs => \@debs) if $a{smoke};
     print "[$pkg] OK (" . scalar(@debs) . " deb(s) in $a{result_dir})\n";
     return scalar @debs;
+}
+
+# smoke_deb_in_chroot(%a): install a produced deb into the chroot it was built in and run a command
+# from it. A cross-built binary links against the TARGET's loader and libraries, neither of which
+# exists on the host, so the only place it can run is the chroot -- and a deb whose binary is the
+# wrong object, or cannot resolve a library, still builds green without this.
+#   %a{smoke}: { deb => qr/.../, run => 'shell command', expect => qr/.../ }
+sub smoke_deb_in_chroot {
+    my (%a) = @_;
+    my $s   = $a{smoke};
+    defined $s->{$_} or die "smoke_deb_in_chroot: missing smoke '$_'\n" for qw(deb run);
+    my ($deb) = grep { basename($_) =~ $s->{deb} } @{ $a{debs} };
+    die "[$a{pkg}] smoke: no produced deb matches $s->{deb} in $a{result_dir}\n" unless $deb;
+
+    my $timeout = chroot_build_timeout($a{chroot});
+    my $log     = "$a{result_dir}/.smoke-$a{pkg}.log";
+    # apt-get, not dpkg -i: it resolves the runtime dependencies the package declares, so a missing
+    # or wrong Depends fails here instead of on a node.
+    my $inner = "set -e\n"
+              . "apt-get -y --no-install-recommends install \"\$1\" >/dev/null 2>&1\n"
+              . $s->{run} . "\n";
+    my $cmd = 'schroot -c ' . sh_quote($a{chroot}) . ' -u root -d / -- bash -c '
+            . sh_quote($inner) . ' bash ' . sh_quote($deb)
+            . ' > ' . sh_quote($log) . ' 2>&1';
+    print "[$a{pkg}] smoke: " . basename($deb) . " in $a{chroot}: $s->{run}\n";
+    require XCAT::BuildUtils;
+    my $r = XCAT::BuildUtils::run_bounded(cmd => $cmd, timeout => $timeout,
+                        label => "[$a{pkg}] smoke in $a{chroot}", out => \*STDOUT);
+    my $out = '';
+    if (open my $lfh, '<', $log) { local $/; $out = <$lfh>; close $lfh; }
+    die "[$a{pkg}] smoke TIMED OUT after $r->{elapsed}s (budget ${timeout}s), log $log\n"
+        if $r->{timed_out};
+    die "[$a{pkg}] smoke failed (rc=$r->{ec}), log $log:\n$out\n" if $r->{ec} != 0;
+    die "[$a{pkg}] smoke ran but its output does not match $s->{expect}, log $log:\n$out\n"
+        if $s->{expect} and $out !~ $s->{expect};
+    unlink $log;
+    print "[$a{pkg}] smoke OK ($a{chroot} ran the packaged binary)\n";
+    return 1;
 }
 
 1;

--- a/BuildUtils.pm
+++ b/BuildUtils.pm
@@ -17,7 +17,10 @@ use warnings;
 use Exporter 'import';
 use File::Basename qw(basename dirname);
 use lib dirname(__FILE__) . '/lib';
-use XCAT::BuildUtils qw(run_bounded emulated_build_timeout);
+# XCAT::BuildUtils is loaded ON DEMAND, not imported here: it pulls in File::Slurper, which the
+# Ubuntu build hosts do not all carry. A compile-time import would make every caller depend on it --
+# including `sbuild-all.pl --install-deps`, the command whose whole job is to install that module on
+# a host that lacks it.
 use File::Copy qw(copy);
 use File::Path qw(make_path);
 use Digest::MD5;
@@ -744,7 +747,8 @@ sub chroot_build_timeout {
     my ($target_arch) = (($chroot // '') =~ /^.+-([^-]+)-sbuild$/);
     my $host_arch = `dpkg --print-architecture 2>/dev/null`;
     chomp $host_arch;
-    return emulated_build_timeout($target_arch, $host_arch);
+    require XCAT::BuildUtils;
+    return XCAT::BuildUtils::emulated_build_timeout($target_arch, $host_arch);
 }
 
 sub build_deb_in_chroot {
@@ -782,7 +786,8 @@ sub build_deb_in_chroot {
     # "still running" rather than as a defect. Bound it, and print the process tree, each wchan and a
     # CPU sample before the kill, so the failure says WHY it stopped.
     my $timeout = defined $a{timeout} ? $a{timeout} : chroot_build_timeout($a{chroot});
-    my $r = run_bounded(cmd => $cmd, timeout => $timeout, label => "[$pkg] build in $a{chroot}",
+    require XCAT::BuildUtils;
+    my $r = XCAT::BuildUtils::run_bounded(cmd => $cmd, timeout => $timeout, label => "[$pkg] build in $a{chroot}",
                         out => \*STDOUT);
     die "[$pkg] build TIMED OUT after $r->{elapsed}s (budget ${timeout}s) -- see the stall report above\n"
         if $r->{timed_out};

--- a/BuildUtils.pm
+++ b/BuildUtils.pm
@@ -801,7 +801,17 @@ sub build_deb_in_chroot {
     die "[$pkg] build succeeded in the chroot but no .deb is visible at $a{result_dir} on the host\n"
       . "  (is --result-dir on a path bind-mounted into the chroot, e.g. under /opt/xcat-ci-shared?)\n"
       unless @debs;
-    smoke_deb_in_chroot(%a, debs => \@debs) if $a{smoke};
+    if ($a{smoke}) {
+        # The debs are already in staging, and the publish gate checks names and versions, not
+        # whether the binary runs. A deb that fails the smoke must not survive the failure, or the
+        # next publish ships exactly the broken binary the smoke exists to catch.
+        my $ok = eval { smoke_deb_in_chroot(%a, debs => \@debs); 1 };
+        unless ($ok) {
+            my $err = $@ || "unknown smoke failure\n";
+            unlink @debs;
+            die $err . "[$pkg] the debs were removed from $a{result_dir}: they did not pass the smoke\n";
+        }
+    }
     print "[$pkg] OK (" . scalar(@debs) . " deb(s) in $a{result_dir})\n";
     return scalar @debs;
 }

--- a/BuildUtils.pm
+++ b/BuildUtils.pm
@@ -81,9 +81,11 @@ sub install_deps_packages {
     # NOTE: no libipc-cmd-perl -- IPC::Cmd is CORE on Debian/Ubuntu (it ships in perl-modules) and
     # no such package exists, so naming it fails the whole install. That it is present is asserted
     # by the module probe, not by installing a package.
+    # A foreign-architecture chroot needs the binfmt handler these two packages register.
     return qw(perl libfile-slurper-perl libparallel-forkmanager-perl
               sbuild schroot debootstrap apt-utils dpkg-dev devscripts equivs quilt fakeroot
-              build-essential reprepro gnupg rsync wget git);
+              build-essential reprepro gnupg rsync wget git
+              qemu-user-static binfmt-support);
 }
 
 # install_deps_command(): the argv that installs them, non-interactively.

--- a/BuildUtils.pm
+++ b/BuildUtils.pm
@@ -22,7 +22,7 @@ use lib dirname(__FILE__) . '/lib';
 # including `sbuild-all.pl --install-deps`, the command whose whole job is to install that module on
 # a host that lacks it.
 use File::Copy qw(copy);
-use File::Path qw(make_path);
+use File::Path qw(make_path remove_tree);
 use Digest::MD5;
 use MIME::Base64 qw(encode_base64);
 
@@ -769,7 +769,17 @@ sub build_deb_in_chroot {
       . "  hide a missing Build-Depends. Add 'union-type=overlay' to its /etc/schroot/chroot.d/ entry\n"
       . "  (or delete the chroot and let sbuild-all.pl re-create it).\n"
         unless chroot_is_disposable($cfg);
+    # Build into a private directory UNDER the result dir, and move the debs into it only after
+    # every check passes. The result dir is what a publish assembles from, and its gate gets no
+    # further than names and versions, so a deb that lands there before the smoke can be published
+    # whatever the smoke would have said -- including when a cancellation kills this process before
+    # any cleanup could run. Same filesystem, so the promotion is a rename.
     make_path($a{result_dir});
+    my $final = $a{result_dir};
+    remove_tree($_) for grep { -d $_ } glob("$final/.build-$pkg.*");
+    my $stage = "$final/.build-$pkg.$$";
+    remove_tree($stage) if -d $stage;
+    make_path($stage);
     my $extra = join(' ', @{ $a{extra_tools} || [] });
     my $b64   = encode_base64($a{build}, '');
 
@@ -780,9 +790,9 @@ sub build_deb_in_chroot {
 
     my $cmd = 'schroot -c ' . sh_quote($a{chroot}) . ' -u root -d / -- bash -c '
             . sh_quote($inner) . ' bash '
-            . sh_quote($a{pkg_dir}) . ' ' . sh_quote($a{result_dir}) . ' '
+            . sh_quote($a{pkg_dir}) . ' ' . sh_quote($stage) . ' '
             . sh_quote($a{build_timestamp}) . ' ' . sh_quote($extra) . ' ' . sh_quote($b64);
-    print "[$pkg] building in chroot $a{chroot} -> $a{result_dir} (SOURCE_DATE_EPOCH=$a{build_timestamp})\n";
+    print "[$pkg] building in chroot $a{chroot} -> $final (SOURCE_DATE_EPOCH=$a{build_timestamp})\n";
     # A build that deadlocks under qemu-user (a resolute goconserver `go build` did, with both Go
     # pids in futex_wait and no CPU ticks at all) used to hang here forever, and a hung cell reads as
     # "still running" rather than as a defect. Bound it, and print the process tree, each wchan and a
@@ -797,23 +807,22 @@ sub build_deb_in_chroot {
     die "[$pkg] build failed (rc=$ec)\n" if $ec != 0;
     # The debs were copied from INSIDE the chroot; that only reaches the host if --result-dir is on a
     # bind-mounted path. Verify host-side so a mis-configured (chroot-local) result-dir fails LOUD.
-    my @debs = glob("$a{result_dir}/*.deb");
-    die "[$pkg] build succeeded in the chroot but no .deb is visible at $a{result_dir} on the host\n"
+    my @debs = glob("$stage/*.deb");
+    die "[$pkg] build succeeded in the chroot but no .deb is visible at $stage on the host\n"
       . "  (is --result-dir on a path bind-mounted into the chroot, e.g. under /opt/xcat-ci-shared?)\n"
       unless @debs;
-    if ($a{smoke}) {
-        # The debs are already in staging, and the publish gate checks names and versions, not
-        # whether the binary runs. A deb that fails the smoke must not survive the failure, or the
-        # next publish ships exactly the broken binary the smoke exists to catch.
-        my $ok = eval { smoke_deb_in_chroot(%a, debs => \@debs); 1 };
-        unless ($ok) {
-            my $err = $@ || "unknown smoke failure\n";
-            unlink @debs;
-            die $err . "[$pkg] the debs were removed from $a{result_dir}: they did not pass the smoke\n";
-        }
+    smoke_deb_in_chroot(%a, result_dir => $stage, debs => \@debs) if $a{smoke};
+
+    # Everything passed: publish the debs by moving them where the assembly step looks.
+    my @published;
+    for my $deb (@debs) {
+        my $target = "$final/" . basename($deb);
+        rename($deb, $target) or die "[$pkg] could not publish $deb as $target: $!\n";
+        push @published, $target;
     }
-    print "[$pkg] OK (" . scalar(@debs) . " deb(s) in $a{result_dir})\n";
-    return scalar @debs;
+    remove_tree($stage);
+    print "[$pkg] OK (" . scalar(@published) . " deb(s) in $final)\n";
+    return scalar @published;
 }
 
 # smoke_deb_in_chroot(%a): install a produced deb into the chroot it was built in and run a command

--- a/debs-manifest.conf
+++ b/debs-manifest.conf
@@ -51,7 +51,13 @@
 # sbuild-all.pl reads this file and, per target, builds ONLY the listed packages and then validates
 # that EVERY listed package was produced at the pinned version -- any missing or mismatched package
 # fails the whole run (zero tolerance; concern #4). The four supported codenames (focal jammy noble
-# resolute) each get an amd64 and a ppc64el section.
+# resolute) each get an amd64, a ppc64el and a riscv64 section.
+#
+# riscv64 differs from ppc64el in two ways. The x86 boot loaders (syslinux-xcat, elilo-xcat,
+# xnba-undi) are NOT listed: a riscv64 node netboots UEFI grub2, exactly as on the EL side, so
+# demanding them would gate on packages that node can never use. And xcat-genesis-base is not
+# listed: riscv64 Genesis is the OpenEmbedded one, published once into the shared pool, not the
+# legacy per-arch netboot image.
 
 # ============================ focal (ubuntu20.04) ============================
 [focal-amd64]
@@ -74,6 +80,12 @@ elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
+[focal-riscv64]
+ipmitool-xcat=1.8.18-4
+conserver-xcat=8.2.1-1
+goconserver=0.3.3-snap*
+grub2-xcat=2.12-1
+
 # ============================ jammy (ubuntu22.04) ============================
 [jammy-amd64]
 ipmitool-xcat=1.8.18-4
@@ -94,6 +106,12 @@ grub2-xcat=2.12-1
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
+
+[jammy-riscv64]
+ipmitool-xcat=1.8.18-4
+conserver-xcat=8.2.1-1
+goconserver=0.3.3-snap*
+grub2-xcat=2.12-1
 
 # ============================ noble (ubuntu24.04) ============================
 [noble-amd64]
@@ -116,6 +134,12 @@ elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
+[noble-riscv64]
+ipmitool-xcat=1.8.18-4
+conserver-xcat=8.2.1-1
+goconserver=0.3.3-snap*
+grub2-xcat=2.12-1
+
 # ============================ resolute (ubuntu26.04) =========================
 [resolute-amd64]
 ipmitool-xcat=1.8.18-4
@@ -136,6 +160,12 @@ grub2-xcat=2.12-1
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
+
+[resolute-riscv64]
+ipmitool-xcat=1.8.18-4
+conserver-xcat=8.2.1-1
+goconserver=0.3.3-snap*
+grub2-xcat=2.12-1
 
 # [shared] is NOT a build target. It describes the ONE pool the OpenEmbedded Genesis release is
 # published into (pool/main/xcat-genesis-openembedded), which every suite indexes and which no

--- a/debs-manifest.conf
+++ b/debs-manifest.conf
@@ -65,7 +65,7 @@ ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
@@ -75,7 +75,7 @@ ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
@@ -84,7 +84,7 @@ xcat-genesis-base=2.*
 ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 
 # ============================ jammy (ubuntu22.04) ============================
 [jammy-amd64]
@@ -92,7 +92,7 @@ ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
@@ -102,7 +102,7 @@ ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
@@ -111,7 +111,7 @@ xcat-genesis-base=2.*
 ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 
 # ============================ noble (ubuntu24.04) ============================
 [noble-amd64]
@@ -119,7 +119,7 @@ ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
@@ -129,7 +129,7 @@ ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
@@ -138,7 +138,7 @@ xcat-genesis-base=2.*
 ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 
 # ============================ resolute (ubuntu26.04) =========================
 [resolute-amd64]
@@ -146,7 +146,7 @@ ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
@@ -156,7 +156,7 @@ ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 elilo-xcat=3.14-6
 xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
@@ -165,7 +165,7 @@ xcat-genesis-base=2.*
 ipmitool-xcat=1.8.18-4
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
-grub2-xcat=2.12-1
+grub2-xcat=2.12-2
 
 # [shared] is NOT a build target. It describes the ONE pool the OpenEmbedded Genesis release is
 # published into (pool/main/xcat-genesis-openembedded), which every suite indexes and which no

--- a/debs-manifest.conf
+++ b/debs-manifest.conf
@@ -61,7 +61,7 @@
 
 # ============================ focal (ubuntu20.04) ============================
 [focal-amd64]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
@@ -71,7 +71,7 @@ xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
 [focal-ppc64el]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
@@ -81,14 +81,14 @@ xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
 [focal-riscv64]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 grub2-xcat=2.12-2
 
 # ============================ jammy (ubuntu22.04) ============================
 [jammy-amd64]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
@@ -98,7 +98,7 @@ xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
 [jammy-ppc64el]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
@@ -108,14 +108,14 @@ xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
 [jammy-riscv64]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 grub2-xcat=2.12-2
 
 # ============================ noble (ubuntu24.04) ============================
 [noble-amd64]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
@@ -125,7 +125,7 @@ xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
 [noble-ppc64el]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
@@ -135,14 +135,14 @@ xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
 [noble-riscv64]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 grub2-xcat=2.12-2
 
 # ============================ resolute (ubuntu26.04) =========================
 [resolute-amd64]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
@@ -152,7 +152,7 @@ xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
 [resolute-ppc64el]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 syslinux-xcat=3.86-2
@@ -162,7 +162,7 @@ xnba-undi=1.21.1-1
 xcat-genesis-base=2.*
 
 [resolute-riscv64]
-ipmitool-xcat=1.8.18-4
+ipmitool-xcat=1.8.18-5
 conserver-xcat=8.2.1-1
 goconserver=0.3.3-snap*
 grub2-xcat=2.12-2

--- a/genesis-openembedded/README.md
+++ b/genesis-openembedded/README.md
@@ -68,7 +68,7 @@ perl ./mockbuild-all.pl \
 
 perl ./sbuild-all.pl \
   --genesis-release /path/to/xcat-genesis-release \
-  --publish --expect-arch "amd64 ppc64el" \
+  --publish --expect-arch "amd64 ppc64el riscv64" \
   [other build options]
 ```
 

--- a/ipmitool/debian/changelog
+++ b/ipmitool/debian/changelog
@@ -1,3 +1,10 @@
+ipmitool-xcat (1.8.18-5) unstable; urgency=low
+
+  * Depend on the shared libraries the binary links against. Readline and
+    ncurses were missing, so the package installed and then failed to run
+
+ -- XCAT <xcat-user@lists.sourceforge.net>  Sun, 06 Sep 2026 12:00:00 +0000
+
 ipmitool-xcat (1.8.18-4) unstable; urgency=low
   * Build with dependencies for either libssl1.0.0 or libssl1.1
 

--- a/ipmitool/debian/control
+++ b/ipmitool/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 12), libreadline-dev, libssl-dev, quilt
 Standards-Version: 3.6.2.1
 
 Package: ipmitool-xcat
-Architecture: i386 amd64 ia64 ppc64el
+Architecture: i386 amd64 ia64 ppc64el riscv64
 Depends: libc6 (>= 2.15), libssl3t64 | libssl3 | libssl1.1
 Suggests: openipmi
 Description: utility for IPMI control with kernel driver or LAN interface

--- a/ipmitool/debian/control
+++ b/ipmitool/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.6.2.1
 
 Package: ipmitool-xcat
 Architecture: i386 amd64 ia64 ppc64el riscv64
-Depends: libc6 (>= 2.15), libssl3t64 | libssl3 | libssl1.1
+Depends: ${shlibs:Depends}, libc6 (>= 2.15), libssl3t64 | libssl3 | libssl1.1
 Suggests: openipmi
 Description: utility for IPMI control with kernel driver or LAN interface
  A utility for managing and configuring devices that support the

--- a/ipmitool/sbuild.pl
+++ b/ipmitool/sbuild.pl
@@ -18,9 +18,9 @@ my $pkg_dir = abs_path($RealBin);
 my $pkg     = basename($pkg_dir);
 my ($codename, $arch, $chroot, $result_dir, $log_dir) = ('', '', '', '', '');
 my ($build_timestamp, $build_number, $skip_install) = (undef, undef, 0);
-# --log-dir / --build-number / --skip-install are accepted for CLI-compat with sbuild-all.pl (which
-# passes them uniformly to every per-package builder) but are intentionally UNUSED here: sbuild-all
-# does its own per-package logging and there is no deb install-smoke. They are parsed and ignored.
+# --log-dir / --build-number are accepted for CLI-compat with sbuild-all.pl (which passes them
+# uniformly to every per-package builder) but are intentionally UNUSED here: sbuild-all does its own
+# per-package logging. --skip-install drops the post-build smoke.
 GetOptions(
     'codename=s' => \$codename, 'arch=s' => \$arch, 'chroot=s' => \$chroot,
     'result-dir=s' => \$result_dir, 'log-dir=s' => \$log_dir,
@@ -34,19 +34,29 @@ $result_dir ||= "$pkg_dir/../build-output/sbuild/$codename/$arch";
 $build_timestamp = time() unless defined $build_timestamp;
 
 # ---- package-specific build (absorbed from the former make_deb.sh); CWD = the copied package dir ----
-# ipmitool is a compiled C package (Architecture: amd64 ppc64el), so it is built per-codename against
+# ipmitool is a compiled C package, so it is built per-codename against
 # that release's libc/toolchain. Extract the upstream tarball, drop in the maintained debian/, build.
-my $build = <<'BUILD';
+my $version = '1.8.18';
+my $build = <<"BUILD";
 set -e
-VERSION=1.8.18
-tar xvfz ipmitool-$VERSION.tar.gz
-cd ipmitool-$VERSION
+VERSION=$version
+tar xvfz ipmitool-\$VERSION.tar.gz
+cd ipmitool-\$VERSION
 cp -rL ../debian .
-HOST_ARCH=$(dpkg --print-architecture)
-TARGET_ARCH=$HOST_ARCH dpkg-buildpackage -uc -us
+HOST_ARCH=\$(dpkg --print-architecture)
+TARGET_ARCH=\$HOST_ARCH dpkg-buildpackage -uc -us
 BUILD
+
+# The chroot is the only place a cross-built binary can run: it holds the target's loader and
+# libraries. Without this an unrunnable ipmitool-xcat ships as a green build.
+my $smoke = {
+    deb    => qr/^ipmitool-xcat_/,
+    run    => '/opt/xcat/bin/ipmitool-xcat -V',
+    expect => qr/ipmitool-xcat version \Q$version\E/i,
+};
 
 build_deb_in_chroot(
     pkg => $pkg, chroot => $chroot, pkg_dir => $pkg_dir, result_dir => $result_dir,
     build_timestamp => $build_timestamp, build => $build,
+    ($skip_install ? () : (smoke => $smoke)),
 );

--- a/lib/XCAT/BuildUtils.pm
+++ b/lib/XCAT/BuildUtils.pm
@@ -20,6 +20,7 @@ our @EXPORT_OK = qw(
   digest_manifest
   display_quote
   every_step_failed
+  forward_signals_to_workers
   hashes_equal
   print_step
   read_binary
@@ -197,6 +198,25 @@ sub stall_report {
         ? "--- no CPU ticks: the build is DEADLOCKED, not slow.\n"
         : "--- the build still consumes CPU: it exceeded the budget rather than deadlocking.\n";
     return $total;
+}
+
+# forward_signals_to_workers(%a): return an INT/TERM/HUP handler that passes the signal on to the
+# forked workers, waits for them, then re-raises it. An orchestrator that dies without this releases
+# its locks while its workers keep building and writing into staging, and the next run races
+# processes it cannot see. run_bounded covers the build inside ONE worker; this covers the workers.
+#   %a: pids (hashref keyed by live worker pid), reap (coderef that waits for them)
+sub forward_signals_to_workers {
+    my (%a) = @_;
+    my $pids = $a{pids} or die "forward_signals_to_workers: missing 'pids'\n";
+    my $reap = $a{reap} or die "forward_signals_to_workers: missing 'reap'\n";
+    return sub {
+        my ($sig) = @_;
+        kill($sig, keys %{$pids});
+        $reap->();
+        # die by the same signal, so the caller's exit status says what happened
+        $SIG{$sig} = 'DEFAULT';
+        kill($sig, $$);
+    };
 }
 
 # run_bounded(%a): run a shell command with a wall-clock budget. On expiry it prints a stall report

--- a/lib/XCAT/BuildUtils.pm
+++ b/lib/XCAT/BuildUtils.pm
@@ -22,6 +22,7 @@ our @EXPORT_OK = qw(
   every_step_failed
   forward_signals_to_workers
   block_handled_signals
+  exit_status
   restore_signal_mask
   hashes_equal
   print_step
@@ -202,6 +203,15 @@ sub stall_report {
     return $total;
 }
 
+# exit_status($status): the exit code of a waited-for child, or 128 plus the signal that killed it.
+# A child killed by a signal has 0 in the high byte, so reading only that byte reports a build the
+# kernel terminated as a build that succeeded.
+sub exit_status {
+    my ($status) = @_;
+    return 0 unless defined $status;
+    return ($status & 127) ? 128 + ($status & 127) : $status >> 8;
+}
+
 # block_handled_signals(): block INT, TERM and HUP and return the previous mask, for the window
 # between forking a child and being able to signal it. A cancellation arriving in that window would
 # otherwise kill the parent under a handler that does not know the child yet, and the child would
@@ -323,8 +333,7 @@ sub run_bounded {
         return { ec => 124, timed_out => 1, elapsed => time - $t0 };
     }
 
-    my $ec = ($status & 127) ? 128 + ($status & 127) : $status >> 8;
-    return { ec => $ec, timed_out => 0, elapsed => time - $t0 };
+    return { ec => exit_status($status), timed_out => 0, elapsed => time - $t0 };
 }
 
 sub display_quote {

--- a/lib/XCAT/BuildUtils.pm
+++ b/lib/XCAT/BuildUtils.pm
@@ -205,7 +205,7 @@ sub stall_report {
 # The command runs in its own process group: a build spawns schroot, mock, qemu and make, and only a
 # group signal reaches all of them. Signalling the group also means no child survives holding the
 # caller's stdout open, which would turn the timeout back into a hang one level up.
-#   %a: cmd (required), timeout (seconds; <=0 runs unbounded), label, sample, out
+#   %a: cmd (required), timeout (seconds; <=0 runs without a deadline), label, sample, out
 # Returns { ec, timed_out, elapsed }. ec is 124 on a timeout, matching timeout(1).
 sub run_bounded {
     my (%a) = @_;
@@ -214,11 +214,6 @@ sub run_bounded {
     my $label   = defined $a{label} ? $a{label} : 'command';
     my $out     = $a{out} || \*STDERR;
     my $t0      = time;
-
-    if ($timeout <= 0) {
-        my $rc = system('bash', '-c', $cmd);
-        return { ec => ($rc == -1 ? -1 : $rc >> 8), timed_out => 0, elapsed => time - $t0 };
-    }
 
     my $pid = fork();
     die "run_bounded: fork failed: $!\n" unless defined $pid;
@@ -253,14 +248,16 @@ sub run_bounded {
     local $SIG{TERM} = $forward;
     local $SIG{HUP}  = $forward;
 
-    my $deadline = $t0 + $timeout;
+    # An unbounded run still forks: it is the process group, not the deadline, that lets a signal
+    # to the orchestrator reach the build.
+    my $deadline = $timeout > 0 ? $t0 + $timeout : undef;
     my $timed_out = 0;
     my $status;
     while (1) {
         my $r = waitpid($pid, POSIX::WNOHANG());
         if ($r == $pid) { $status = $?; last; }
         if ($r == -1)   { $status = 0;  last; }
-        if (time >= $deadline) { $timed_out = 1; last; }
+        if (defined $deadline and time >= $deadline) { $timed_out = 1; last; }
         Time::HiRes::sleep(0.5);
     }
 

--- a/lib/XCAT/BuildUtils.pm
+++ b/lib/XCAT/BuildUtils.pm
@@ -10,6 +10,8 @@ use File::Find qw(find);
 use File::Slurper qw(read_binary write_binary);
 use File::Spec;
 use IPC::Cmd qw(can_run);
+use POSIX ();
+use Time::HiRes ();
 
 our @EXPORT_OK = qw(
   capture_command
@@ -25,8 +27,11 @@ our @EXPORT_OK = qw(
   read_lines
   relative_files
   require_command
+  run_bounded
   run_command
   shell_quote
+  stall_report
+  emulated_build_timeout
   write_binary
 );
 
@@ -62,6 +67,199 @@ sub run_command {
       : ($status & 127) ? 128 + ($status & 127) : $status >> 8;
     die "Command failed (rc=$exit): "
       . join(' ', map { display_quote($_) } @command) . "\n";
+}
+
+# ---------------------------------------------------------------------------------------------------
+# Bounded command execution (build steps that can run under emulation)
+# ---------------------------------------------------------------------------------------------------
+
+# NATIVE_BUILD_TIMEOUT: the per-package wall-clock budget for a build on the host architecture.
+# EMULATION_FACTOR: qemu-user under TCG runs at roughly a tenth of native speed, so a foreign-arch
+# target gets ten times the budget. Both numbers come from measured runs of this tree, not a guess:
+# on xcat-master-ub the slowest native (amd64) package took 3 minutes, and the slowest emulated
+# (riscv64) package -- ipmitool-xcat on resolute -- took 26 minutes with four codenames building at
+# once. 900s and 9000s therefore sit about five times above the worst build ever measured, which is
+# the margin that keeps a busy host from producing a false failure.
+our $NATIVE_BUILD_TIMEOUT = 900;
+our $EMULATION_FACTOR     = 10;
+
+# emulated_build_timeout($target_arch, $host_arch): the budget for a build of $target_arch on
+# $host_arch. Equal arches are native. Any other pair is emulated through qemu-user.
+sub emulated_build_timeout {
+    my ($target_arch, $host_arch) = @_;
+    return $NATIVE_BUILD_TIMEOUT
+      if !defined($target_arch) || !defined($host_arch) || $target_arch eq $host_arch;
+    return $NATIVE_BUILD_TIMEOUT * $EMULATION_FACTOR;
+}
+
+# proc_pgid_pids($pgid): every live pid in process group $pgid, read from /proc rather than matched
+# against a command line. `pgrep -af X | grep -c Y` counts its own command line, and bracketing the
+# pattern still self-matches when the surrounding command carries the bare word, so this code never
+# matches text at all.
+sub proc_pgid_pids {
+    my ($pgid) = @_;
+    my @pids;
+    opendir(my $dh, '/proc') or return ();
+    for my $e (sort { $a <=> $b } grep { /^\d+$/ } readdir($dh)) {
+        my $f = _proc_stat_fields($e) or next;
+        push @pids, $e if defined($f->{pgrp}) && $f->{pgrp} == $pgid;
+    }
+    closedir($dh);
+    return @pids;
+}
+
+# _proc_stat_fields($pid): the /proc/<pid>/stat fields this module reads. The comm field is wrapped
+# in parentheses and may itself contain a space or a parenthesis, so the split starts after the LAST
+# ')'.
+sub _proc_stat_fields {
+    my ($pid) = @_;
+    open(my $fh, q{<}, "/proc/$pid/stat") or return;
+    my $line = <$fh>;
+    close($fh);
+    return unless defined $line;
+    my $close = rindex($line, ')');
+    return if $close < 0;
+    my $comm = substr($line, index($line, '(') + 1, $close - index($line, '(') - 1);
+    my @f = split(' ', substr($line, $close + 2));
+    return {
+        comm  => $comm,
+        state => $f[0],
+        ppid  => $f[1],
+        pgrp  => $f[2],
+        ticks => (($f[11] // 0) + ($f[12] // 0)),
+    };
+}
+
+sub _proc_read {
+    my ($path) = @_;
+    open(my $fh, '<', $path) or return '';
+    local $/;
+    my $t = <$fh> // '';
+    close($fh);
+    $t =~ s/\0/ /g;
+    $t =~ s/\s+\z//;
+    return $t;
+}
+
+# _proc_socket_count($pid): how many of the pid's descriptors are sockets. A build that is waiting on
+# the network holds one; the deadlock this bound exists for held none.
+sub _proc_socket_count {
+    my ($pid) = @_;
+    opendir(my $dh, "/proc/$pid/fd") or return -1;
+    my $n = 0;
+    for my $fd (grep { /^\d+$/ } readdir($dh)) {
+        my $l = readlink("/proc/$pid/fd/$fd") // '';
+        $n++ if $l =~ /^socket:/;
+    }
+    closedir($dh);
+    return $n;
+}
+
+# stall_report($pgid, %opt): the evidence a hung build needs, gathered before the kill. For every pid
+# in the process group it prints the parent, the state, the kernel wchan and stack, the socket count,
+# and the CPU ticks the pid consumed across a sample window. The tick delta is what separates a
+# deadlock from a slow build: a package that is merely slow keeps accumulating ticks, and the
+# goconserver deadlock this bound exists for accumulated none over twenty seconds.
+#   %opt: sample (seconds, default 20), out (filehandle, default STDERR)
+sub stall_report {
+    my ($pgid, %opt) = @_;
+    my $sample = defined $opt{sample} ? $opt{sample} : 20;
+    my $out    = $opt{out} || \*STDERR;
+
+    my @pids = proc_pgid_pids($pgid);
+    my %before = map { $_ => (_proc_stat_fields($_) || {})->{ticks} } @pids;
+    sleep($sample) if $sample > 0;
+    my @after_pids = proc_pgid_pids($pgid);
+    my %seen = map { $_ => 1 } @pids;
+    push @pids, grep { !$seen{$_} } @after_pids;
+
+    my $total = 0;
+    print {$out} "--- stall report: process group $pgid, ${sample}s CPU sample ---\n";
+    printf {$out} "%-8s %-8s %-5s %-10s %-10s %-24s %s\n",
+        'PID', 'PPID', 'STAT', 'TICKS', 'DELTA', 'WCHAN', 'CMD';
+    for my $pid (@pids) {
+        my $f = _proc_stat_fields($pid) or next;
+        my $delta = ($f->{ticks} // 0) - ($before{$pid} // 0);
+        $delta = 0 if $delta < 0;
+        $total += $delta;
+        my $cmd = _proc_read("/proc/$pid/cmdline") || "[$f->{comm}]";
+        $cmd = substr($cmd, 0, 120);
+        printf {$out} "%-8s %-8s %-5s %-10s %-10s %-24s %s\n",
+            $pid, $f->{ppid}, $f->{state}, $f->{ticks}, $delta,
+            (_proc_read("/proc/$pid/wchan") || '?'), $cmd;
+        my $stack = _proc_read("/proc/$pid/stack");
+        print {$out} "    stack: $_\n" for grep { length } split(/\n/, $stack);
+        my $socks = _proc_socket_count($pid);
+        print {$out} "    sockets: $socks\n" if $socks >= 0;
+    }
+    print {$out} "--- CPU ticks consumed by the whole group during the sample: $total\n";
+    print {$out} $total == 0
+        ? "--- no CPU ticks: the build is DEADLOCKED, not slow.\n"
+        : "--- the build still consumes CPU: it exceeded the budget rather than deadlocking.\n";
+    return $total;
+}
+
+# run_bounded(%a): run a shell command with a wall-clock budget. On expiry it prints a stall report
+# and kills the whole process group, so a build that deadlocks fails LOUDLY instead of hanging a
+# pipeline forever -- an unbounded hang reads as "still running", never as a defect.
+# The command runs in its own process group: a build spawns schroot, mock, qemu and make, and only a
+# group signal reaches all of them. Signalling the group also means no child survives holding the
+# caller's stdout open, which would turn the timeout back into a hang one level up.
+#   %a: cmd (required), timeout (seconds; <=0 runs unbounded), label, sample, out
+# Returns { ec, timed_out, elapsed }. ec is 124 on a timeout, matching timeout(1).
+sub run_bounded {
+    my (%a) = @_;
+    my $cmd     = defined $a{cmd} ? $a{cmd} : die "run_bounded: missing 'cmd'\n";
+    my $timeout = $a{timeout} || 0;
+    my $label   = defined $a{label} ? $a{label} : 'command';
+    my $out     = $a{out} || \*STDERR;
+    my $t0      = time;
+
+    if ($timeout <= 0) {
+        my $rc = system('bash', '-c', $cmd);
+        return { ec => ($rc == -1 ? -1 : $rc >> 8), timed_out => 0, elapsed => time - $t0 };
+    }
+
+    my $pid = fork();
+    die "run_bounded: fork failed: $!\n" unless defined $pid;
+    if ($pid == 0) {
+        POSIX::setpgid(0, 0);
+        exec('bash', '-c', $cmd) or POSIX::_exit(127);
+    }
+    # setpgid from BOTH sides: whichever runs first wins, so the group exists before the first signal
+    # whatever the scheduler does.
+    POSIX::setpgid($pid, $pid);
+
+    my $deadline = $t0 + $timeout;
+    my $timed_out = 0;
+    my $status;
+    while (1) {
+        my $r = waitpid($pid, POSIX::WNOHANG());
+        if ($r == $pid) { $status = $?; last; }
+        if ($r == -1)   { $status = 0;  last; }
+        if (time >= $deadline) { $timed_out = 1; last; }
+        Time::HiRes::sleep(0.5);
+    }
+
+    if ($timed_out) {
+        my $el = time - $t0;
+        print {$out} "\nFATAL: $label exceeded its ${timeout}s budget (ran ${el}s).\n";
+        eval { stall_report($pid, sample => (defined $a{sample} ? $a{sample} : 20), out => $out); 1 }
+          or print {$out} "stall report failed: $@";
+        kill('TERM', -$pid);
+        for (1 .. 40) {
+            last if waitpid($pid, POSIX::WNOHANG()) == $pid;
+            select(undef, undef, undef, 0.5);
+        }
+        kill('KILL', -$pid);
+        # Unconditional final reap: a child left unreaped keeps the group alive and the caller blocks
+        # on output that never ends.
+        waitpid($pid, 0);
+        return { ec => 124, timed_out => 1, elapsed => time - $t0 };
+    }
+
+    my $ec = ($status & 127) ? 128 + ($status & 127) : $status >> 8;
+    return { ec => $ec, timed_out => 0, elapsed => time - $t0 };
 }
 
 sub display_quote {

--- a/lib/XCAT/BuildUtils.pm
+++ b/lib/XCAT/BuildUtils.pm
@@ -235,10 +235,22 @@ sub run_bounded {
     my $out     = $a{out} || \*STDERR;
     my $t0      = time;
 
+    # Block the handled signals across the fork. A cancellation landing between fork() and the
+    # handler below would kill this process under the inherited handler and leave the new process
+    # group running. A blocked signal stays pending and is delivered once the handler is in place.
+    # The child restores the mask before exec, or the build would inherit a blocked TERM.
+    my $handled  = POSIX::SigSet->new(POSIX::SIGINT(), POSIX::SIGTERM(), POSIX::SIGHUP());
+    my $previous = POSIX::SigSet->new();
+    POSIX::sigprocmask(POSIX::SIG_BLOCK(), $handled, $previous);
+
     my $pid = fork();
-    die "run_bounded: fork failed: $!\n" unless defined $pid;
+    unless (defined $pid) {
+        POSIX::sigprocmask(POSIX::SIG_SETMASK(), $previous);
+        die "run_bounded: fork failed: $!\n";
+    }
     if ($pid == 0) {
         POSIX::setpgid(0, 0);
+        POSIX::sigprocmask(POSIX::SIG_SETMASK(), $previous);
         exec('bash', '-c', $cmd) or POSIX::_exit(127);
     }
     # setpgid from BOTH sides: whichever runs first wins, so the group exists before the first signal
@@ -267,6 +279,7 @@ sub run_bounded {
     local $SIG{INT}  = $forward;
     local $SIG{TERM} = $forward;
     local $SIG{HUP}  = $forward;
+    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $previous);
 
     # An unbounded run still forks: it is the process group, not the deadline, that lets a signal
     # to the orchestrator reach the build.

--- a/lib/XCAT/BuildUtils.pm
+++ b/lib/XCAT/BuildUtils.pm
@@ -333,7 +333,15 @@ sub run_bounded {
         return { ec => 124, timed_out => 1, elapsed => time - $t0 };
     }
 
-    return { ec => exit_status($status), timed_out => 0, elapsed => time - $t0 };
+    my $ec = exit_status($status);
+    # The leader can die without its descendants. A SIGKILL, or the OOM killer, takes the shell but
+    # leaves schroot and qemu in its process group, still holding the chroot and writing into
+    # staging after this call reports the build finished. They are not children of this process, so
+    # there is nothing to wait for: signal the group and move on.
+    kill('TERM', -$pid);
+    Time::HiRes::sleep(0.2);
+    kill('KILL', -$pid);
+    return { ec => $ec, timed_out => 0, elapsed => time - $t0 };
 }
 
 sub display_quote {

--- a/lib/XCAT/BuildUtils.pm
+++ b/lib/XCAT/BuildUtils.pm
@@ -230,6 +230,29 @@ sub run_bounded {
     # whatever the scheduler does.
     POSIX::setpgid($pid, $pid);
 
+    # A signal to this process must reach the build too. Without this the orchestrator dies and
+    # releases its locks while schroot, mock and qemu keep writing into staging, so the next run
+    # races an orphan it cannot see.
+    my $reap_group = sub {
+        kill('TERM', -$pid);
+        for (1 .. 40) {
+            last if waitpid($pid, POSIX::WNOHANG()) == $pid;
+            Time::HiRes::sleep(0.5);
+        }
+        kill('KILL', -$pid);
+        waitpid($pid, 0);
+    };
+    my $forward = sub {
+        my ($sig) = @_;
+        $reap_group->();
+        # die by the same signal, so the caller's exit status says what happened
+        $SIG{$sig} = 'DEFAULT';
+        kill($sig, $$);
+    };
+    local $SIG{INT}  = $forward;
+    local $SIG{TERM} = $forward;
+    local $SIG{HUP}  = $forward;
+
     my $deadline = $t0 + $timeout;
     my $timed_out = 0;
     my $status;
@@ -246,15 +269,9 @@ sub run_bounded {
         print {$out} "\nFATAL: $label exceeded its ${timeout}s budget (ran ${el}s).\n";
         eval { stall_report($pid, sample => (defined $a{sample} ? $a{sample} : 20), out => $out); 1 }
           or print {$out} "stall report failed: $@";
-        kill('TERM', -$pid);
-        for (1 .. 40) {
-            last if waitpid($pid, POSIX::WNOHANG()) == $pid;
-            select(undef, undef, undef, 0.5);
-        }
-        kill('KILL', -$pid);
-        # Unconditional final reap: a child left unreaped keeps the group alive and the caller blocks
-        # on output that never ends.
-        waitpid($pid, 0);
+        # Unconditional final reap: a child left unreaped keeps the group alive and the caller
+        # blocks on output that never ends.
+        $reap_group->();
         return { ec => 124, timed_out => 1, elapsed => time - $t0 };
     }
 

--- a/lib/XCAT/BuildUtils.pm
+++ b/lib/XCAT/BuildUtils.pm
@@ -21,6 +21,8 @@ our @EXPORT_OK = qw(
   display_quote
   every_step_failed
   forward_signals_to_workers
+  block_handled_signals
+  restore_signal_mask
   hashes_equal
   print_step
   read_binary
@@ -200,6 +202,24 @@ sub stall_report {
     return $total;
 }
 
+# block_handled_signals(): block INT, TERM and HUP and return the previous mask, for the window
+# between forking a child and being able to signal it. A cancellation arriving in that window would
+# otherwise kill the parent under a handler that does not know the child yet, and the child would
+# keep running. A blocked signal stays pending and is delivered by restore_signal_mask().
+sub block_handled_signals {
+    my $handled  = POSIX::SigSet->new(POSIX::SIGINT(), POSIX::SIGTERM(), POSIX::SIGHUP());
+    my $previous = POSIX::SigSet->new();
+    POSIX::sigprocmask(POSIX::SIG_BLOCK(), $handled, $previous);
+    return $previous;
+}
+
+# restore_signal_mask($previous): put the mask back, delivering anything that arrived meanwhile.
+sub restore_signal_mask {
+    my ($previous) = @_;
+    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $previous) if $previous;
+    return;
+}
+
 # forward_signals_to_workers(%a): return an INT/TERM/HUP handler that passes the signal on to the
 # forked workers, waits for them, then re-raises it. An orchestrator that dies without this releases
 # its locks while its workers keep building and writing into staging, and the next run races
@@ -239,18 +259,16 @@ sub run_bounded {
     # handler below would kill this process under the inherited handler and leave the new process
     # group running. A blocked signal stays pending and is delivered once the handler is in place.
     # The child restores the mask before exec, or the build would inherit a blocked TERM.
-    my $handled  = POSIX::SigSet->new(POSIX::SIGINT(), POSIX::SIGTERM(), POSIX::SIGHUP());
-    my $previous = POSIX::SigSet->new();
-    POSIX::sigprocmask(POSIX::SIG_BLOCK(), $handled, $previous);
+    my $previous = block_handled_signals();
 
     my $pid = fork();
     unless (defined $pid) {
-        POSIX::sigprocmask(POSIX::SIG_SETMASK(), $previous);
+        restore_signal_mask($previous);
         die "run_bounded: fork failed: $!\n";
     }
     if ($pid == 0) {
         POSIX::setpgid(0, 0);
-        POSIX::sigprocmask(POSIX::SIG_SETMASK(), $previous);
+        restore_signal_mask($previous);
         exec('bash', '-c', $cmd) or POSIX::_exit(127);
     }
     # setpgid from BOTH sides: whichever runs first wins, so the group exists before the first signal
@@ -279,7 +297,7 @@ sub run_bounded {
     local $SIG{INT}  = $forward;
     local $SIG{TERM} = $forward;
     local $SIG{HUP}  = $forward;
-    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $previous);
+    restore_signal_mask($previous);
 
     # An unbounded run still forks: it is the process group, not the deadline, that lets a signal
     # to the orchestrator reach the build.

--- a/mockbuild-all.pl
+++ b/mockbuild-all.pl
@@ -28,7 +28,9 @@ use XCAT::BuildUtils qw(
   every_step_failed
   hashes_equal
   read_lines
+  emulated_build_timeout
   require_command
+  run_bounded
   run_command
   shell_quote
 );
@@ -88,6 +90,9 @@ my $parallel_targets = 1;   # 1 = serial (default; safe). 0/auto = all EL target
                             # NOTE: parallel targets need every per-package mockbuild.pl to avoid
                             # shared-path writes (repo tarballs, $HOME/rpmbuild); serial is safe today.
 my $max_parallel = 0;       # 0/auto = host nproc: global cap on concurrent mock builds (all targets)
+# Per-build-step wall-clock bound for the dep and perl steps. undef = derived from the target arch
+# (a forcearch target is cross-built through qemu-user); an explicit 0 removes the bound.
+my $build_timeout;
 my $run_id     = '';
 my $build_timestamp;
 # CD version bump: when set, every xcat-dep package spec's Release gets a
@@ -157,6 +162,7 @@ GetOptions(
     'parallel-builds=i' => \$parallel_builds,
     'parallel-targets=i' => \$parallel_targets,
     'max-parallel=i'    => \$max_parallel,
+    'build-timeout=i'   => \$build_timeout,
     'run-id=s'          => \$run_id,
     'build-timestamp=i' => \$build_timestamp,
     'build-number=i'    => \$build_number,
@@ -596,6 +602,15 @@ if (!$skip_build) {
     my @build_steps;
     my $build_step_seq = 0;
 
+    # Bound only what can run emulated. A forcearch target (rocky-10-riscv64-xcat) cross-builds every
+    # dep through qemu-user, where a deadlock burns no CPU and never returns. Native mock steps keep
+    # their present, unbounded behaviour: no measurement of them exists here, and a bound guessed for
+    # a step that legitimately runs long would turn a trusted cell red for no reason.
+    # --build-timeout overrides both; 0 removes the bound.
+    my $step_timeout = defined $build_timeout ? $build_timeout
+                     : $profile->{forcearch}  ? emulated_build_timeout($arch, $host_arch)
+                     :                          0;
+
     if (!$skip_xcat_dep) {
         for my $builder (@active_dep_builders) {
             next unless $req{ $builder->{name} };   # manifest: build only required dep packages
@@ -624,10 +639,11 @@ if (!$skip_build) {
                     : ()),
             );
             push @build_steps, {
-                id   => "xcat-dep:$name",
-                step => "Build xcat-dep: $name",
-                cmd  => $cmd,
-                log  => "$log_root/$name/run.log",
+                id      => "xcat-dep:$name",
+                step    => "Build xcat-dep: $name",
+                cmd     => $cmd,
+                timeout => $step_timeout,
+                log     => "$log_root/$name/run.log",
                 scrub_cfg       => $target,
                 scrub_uniqueext => $step_uniqueext,
             };
@@ -664,10 +680,13 @@ if (!$skip_build) {
             ($keep_buildroots ? '--keep-buildroots' : ()),
         );
         push @build_steps, {
-            id   => 'perl',
-            step => 'Build perl xcat-dep packages',
-            cmd  => $cmd,
-            log  => "$log_root/perl-build.log",
+            id      => 'perl',
+            step    => 'Build perl xcat-dep packages',
+            cmd     => $cmd,
+            # The perl builder forks its own mock jobs, so under forcearch it is emulated too. Give it
+            # the per-package budget times the number of packages it builds serially per worker.
+            timeout => ($step_timeout ? $step_timeout * scalar(@perl_pkgs) : 0),
+            log     => "$log_root/perl-build.log",
         };
         push @collect_roots, $perl_result;
     }
@@ -1351,6 +1370,12 @@ Options:
                           cross-builds that arch on this host); default is the host arch
                           across rh8, rh9 and rh10
   --nproc N               Parallel jobs for buildrpms.pl (default: 1)
+  --build-timeout SECONDS Wall-clock bound for one build step. Default: none for a native
+                          target, and 9000 for a forcearch (qemu-user) target, which runs at
+                          roughly a tenth of native speed. 0 removes the bound. On expiry the
+                          run prints the step's process tree, each pid's wchan and stack, and
+                          a 20-second CPU sample -- a deadlocked build uses no ticks -- then
+                          kills the whole process group.
   --parallel-builds N     Max concurrent top-level build steps within one EL target (default: auto)
   --parallel-targets N    Concurrent EL targets (rh8/rh9/rh10). 0/auto = all at once, 1 = serial,
                           N = cap at N. Each target is fully output-isolated (default: 1 = serial)
@@ -1422,9 +1447,15 @@ sub run_step {
         $full_cmd .= " > " . shell_quote($log) . " 2>&1";
     }
 
-    my $rc = system($full_cmd);
-    if ($rc != 0) {
-        my $exit = $rc == -1 ? 255 : ($rc >> 8);
+    # A forcearch step cross-builds through qemu-user, where a deadlocked build consumes no CPU and
+    # never exits. Bound the steps that can run emulated, and report why the build stopped.
+    my $timeout = $args{timeout} || 0;
+    my $r = run_bounded(cmd => $full_cmd, timeout => $timeout, label => $step, out => \*STDOUT);
+    die "Step TIMED OUT after $r->{elapsed}s (budget ${timeout}s): $step\nCommand: $cmd\n"
+      . "  See the stall report above" . ($log ? " and $log" : '') . ".\n"
+        if $r->{timed_out};
+    if ($r->{ec} != 0) {
+        my $exit = $r->{ec} == -1 ? 255 : $r->{ec};
         die "Step failed (rc=$exit): $step\nCommand: $cmd\n";
     }
 }

--- a/mockbuild-all.pl
+++ b/mockbuild-all.pl
@@ -27,6 +27,8 @@ use XCAT::BuildUtils qw(
   capture_command
   every_step_failed
   forward_signals_to_workers
+  block_handled_signals
+  restore_signal_mask
   hashes_equal
   read_lines
   emulated_build_timeout
@@ -444,9 +446,11 @@ my $tgt_fail = 0;
 my %tgt_kids;
 $tgt_pm->run_on_start(sub { $tgt_kids{ $_[0] } = 1 });
 $tgt_pm->run_on_finish(sub {
-    my ($pid, $exit) = @_;
+    my ($pid, $exit, $ident, $signal, $core_dump) = @_;
     delete $tgt_kids{$pid};
-    $tgt_fail++ if $exit;
+    # A worker killed by a signal exits with code 0 in this callback, so reading the code alone
+    # reports a target that died mid-deploy as built.
+    $tgt_fail++ if $exit or $signal or $core_dump;
 });
 my $tgt_forward = forward_signals_to_workers(
     pids => \%tgt_kids,
@@ -456,7 +460,19 @@ local $SIG{INT}  = $tgt_forward;
 local $SIG{TERM} = $tgt_forward;
 local $SIG{HUP}  = $tgt_forward;
 for my $tgt (@build_targets) {
-    $tgt_pm->start and next;
+    # ForkManager records the worker in run_on_start, which runs AFTER the fork, so the handler
+    # cannot signal a worker that arrives in between. Hold the signals across both -- but wait for
+    # a free slot FIRST, with them unblocked, or a cancellation would sit pending for as long as
+    # the pool stays full.
+    # max_procs 0 is ForkManager's no-fork mode, where asking for a slot is an error.
+    $tgt_pm->wait_for_available_procs(1) if $tgt_pm->max_procs;
+    my $orchestrator = $$;
+    my $previous     = block_handled_signals();
+    if ($tgt_pm->start) { restore_signal_mask($previous); next; }
+    # With one worker ForkManager does not fork at all, and this is still the orchestrator: only a
+    # real child drops the forwarder, whose copy names siblings the parent already signals.
+    $SIG{$_} = 'DEFAULT' for ($$ == $orchestrator ? () : qw(INT TERM HUP));
+    restore_signal_mask($previous);
     my $rc = 0;
     eval {
         my $info = build_one_target($tgt, $run_id, $per_target_builds);
@@ -1562,8 +1578,15 @@ sub run_build_steps_parallel {
         my $ident = delete $step_copy{id};
         $ident = $step_copy{step} if !defined($ident) || $ident eq '';
 
+        # Same window as the per-target workers, and the same rule about waiting for a slot with
+        # the signals unblocked.
+        $pm->wait_for_available_procs(1) if $pm->max_procs;
+        my $orchestrator = $$;
+        my $previous     = block_handled_signals();
         my $pid = $pm->start($ident);
-        next if $pid;
+        if ($pid) { restore_signal_mask($previous); next; }
+        $SIG{$_} = 'DEFAULT' for ($$ == $orchestrator ? () : qw(INT TERM HUP));
+        restore_signal_mask($previous);
 
         my $ok = eval {
             run_step(%step_copy);

--- a/mockbuild-all.pl
+++ b/mockbuild-all.pl
@@ -26,6 +26,7 @@ use MockBuildUtils qw(sh_quote print_step version_matches required_pkgs
 use XCAT::BuildUtils qw(
   capture_command
   every_step_failed
+  forward_signals_to_workers
   hashes_equal
   read_lines
   emulated_build_timeout
@@ -438,10 +439,22 @@ print "parallel_targets: " . ($parallel_targets > 0 ? $parallel_targets : "auto(
 print "max_parallel:     $cap (per-target build workers: $per_target_builds)\n";
 my $tgt_pm = Parallel::ForkManager->new($tgt_workers <= 1 ? 0 : $tgt_workers);
 my $tgt_fail = 0;
+# A signal to this process must reach the forked workers. Without forwarding, the orchestrator exits
+# and releases its locks while the workers keep building and writing into the deploy tree.
+my %tgt_kids;
+$tgt_pm->run_on_start(sub { $tgt_kids{ $_[0] } = 1 });
 $tgt_pm->run_on_finish(sub {
     my ($pid, $exit) = @_;
+    delete $tgt_kids{$pid};
     $tgt_fail++ if $exit;
 });
+my $tgt_forward = forward_signals_to_workers(
+    pids => \%tgt_kids,
+    reap => sub { $tgt_pm->wait_all_children },
+);
+local $SIG{INT}  = $tgt_forward;
+local $SIG{TERM} = $tgt_forward;
+local $SIG{HUP}  = $tgt_forward;
 for my $tgt (@build_targets) {
     $tgt_pm->start and next;
     my $rc = 0;
@@ -1519,9 +1532,12 @@ sub run_build_steps_parallel {
 
     my %failed;
     my $pm = Parallel::ForkManager->new($workers);
+    my %kids;
+    $pm->run_on_start(sub { $kids{ $_[0] } = 1 });
     $pm->run_on_finish(
         sub {
             my ($pid, $exit_code, $ident, $signal, $core_dump) = @_;
+            delete $kids{$pid};
             return if $exit_code == 0 && $signal == 0 && !$core_dump;
             my $key = defined($ident) ? $ident : "pid:$pid";
             $failed{$key} = {
@@ -1531,6 +1547,15 @@ sub run_build_steps_parallel {
             };
         }
     );
+
+    # Same reason as the per-target workers: a signal here must reach the builds these workers run.
+    my $forward = forward_signals_to_workers(
+        pids => \%kids,
+        reap => sub { $pm->wait_all_children },
+    );
+    local $SIG{INT}  = $forward;
+    local $SIG{TERM} = $forward;
+    local $SIG{HUP}  = $forward;
 
     for my $step (@{$steps}) {
         my %step_copy = %{$step};

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -74,6 +74,9 @@ my $build_number;
 # arches on their two hosts in parallel, "all 4 codenames per host" gives 8 concurrent build streams
 # (4 per host). N caps it to N; 1 forces serial.
 my $parallel_targets = 0;
+# Per-package wall-clock bound. undef = the arch-derived default in BuildUtils::chroot_build_timeout
+# (native vs qemu-user emulated); an explicit 0 disables the bound.
+my $build_timeout;
 my ($skip_build, $skip_install, $skip_genesis, $skip_xcat_dep) = (0,0,0,0);
 my $install_deps = 0;
 my ($skip_createrepo, $skip_tarball) = (0,0);
@@ -175,6 +178,7 @@ $spec{'apt-dir=s'}             = \$apt_dir;
 $spec{'mirror=s'}              = \$mirror;
 $spec{'gpg-key-id=s'}          = \$gpg_key_id;
 $spec{'parallel-targets=i'}    = \$parallel_targets;
+$spec{'build-timeout=i'}       = \$build_timeout;   # per-package wall-clock bound (0 = unbounded)
 $spec{'genesis-deb=s'}         = \@genesis_debs;
 $spec{'genesis-rpm=s'}         = \$genesis_rpm;
 $spec{'genesis-rpm-ppc=s'}     = \$genesis_rpm_ppc;
@@ -358,6 +362,10 @@ unless ($dry_run) {
     }
 }
 
+# The per-package builders are separate processes with their own CLI, so the bound travels to them in
+# the environment. Without it each one derives the same default from its chroot arch.
+$ENV{XCAT_DEP_BUILD_TIMEOUT} = $build_timeout if defined $build_timeout;
+
 print_step('Configuration');
 print "  repo-root:   $repo_root\n";
 print "  xcat-source: $xcat_src\n";
@@ -374,6 +382,10 @@ print "  publish:     " . ($publish
 print "  expect-arch: " . (@expect_arch ? "@expect_arch" : '(derive from the staged arch set)') . "\n"
     if $publish;
 print "  dry-run:     " . ($dry_run ? "yes" : "no") . "\n";
+print "  build-timeout: " . (defined $build_timeout
+    ? ($build_timeout > 0 ? "${build_timeout}s (explicit)" : 'disabled')
+    : BuildUtils::chroot_build_timeout(chroot_name($dist_list[0], $arch)) . "s (derived: "
+      . ($arch eq (do { my $h = `dpkg --print-architecture 2>/dev/null`; chomp $h; $h }) ? 'native' : 'emulated') . ")") . "\n";
 
 # ---------------------------------------------------------------------------------------------------
 # Helpers
@@ -1506,6 +1518,16 @@ CD identifiers; C<--build-timestamp> also sets C<SOURCE_DATE_EPOCH> for reproduc
 Per-codename build concurrency on this host. Default 0 = auto = build every requested codename in
 parallel (each in its own chroot); N caps it; 1 forces serial. With the two arches on their two hosts,
 the default gives 8 concurrent build streams for a 4-codename matrix (4 per host).
+
+=item B<--build-timeout> C<SECONDS>
+
+Wall-clock bound for ONE package build, passed to every per-package builder in
+C<XCAT_DEP_BUILD_TIMEOUT>. C<0> removes the bound. The default is derived from the target
+architecture: 900s for a native build, and ten times that for a foreign architecture, because
+qemu-user under TCG runs at roughly a tenth of native speed. When the bound expires the run prints
+the process tree of the build, each pid's kernel wchan and stack, its open socket count and the CPU
+ticks it used over a 20-second sample, then kills the whole process group. The sample is the
+evidence that separates a deadlocked build from a slow one.
 
 =item B<--skip-build> B<--skip-install> B<--skip-genesis> B<--skip-xcat-dep> B<--skip-createrepo> B<--skip-tarball>
 

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -50,7 +50,8 @@ use BuildUtils qw(sh_quote print_step version_matches required_pkgs read_manifes
                   verify_repo_packages verify_repo_signature verify_repo_arches
                   parse_packages_index parse_release_architectures resolve_present_names
                   index_has_native_arch control_binary_arch skip_arch_all_on
-                  codename_to_version known_codenames chroot_name chroot_sources_list
+                  codename_to_version known_codenames supported_arches is_supported_arch
+                  chroot_name chroot_sources_list
                   chroot_is_disposable
                   control_field genesis_deb_control
                   deb_field deb_version deb_hash cross_copy_genesis_deb);
@@ -220,16 +221,17 @@ $xcat_src  = abs_path($xcat_src) if -d $xcat_src;
 $manifest  ||= "$repo_root/debs-manifest.conf";
 $arch      ||= `dpkg --print-architecture 2>/dev/null`; chomp $arch;
 $arch      ||= 'amd64';
-die "FATAL: unsupported --arch '$arch' (amd64|ppc64el)\n" unless $arch =~ /^(amd64|ppc64el)$/;
-# Arch-aware chroot bootstrap mirror: ppc64el is NOT served by archive.ubuntu.com -- it lives on
-# ubuntu-ports. Only defaulted when --mirror was not given explicitly.
-$mirror    ||= ($arch eq 'ppc64el') ? 'http://ports.ubuntu.com/ubuntu-ports'
-                                     : 'http://br.archive.ubuntu.com/ubuntu';
+die "FATAL: unsupported --arch '$arch' (@{[join '|', supported_arches()]})\n" unless is_supported_arch($arch);
+# Arch-aware chroot bootstrap mirror: only amd64 is on archive.ubuntu.com. Every secondary
+# architecture -- ppc64el and riscv64 -- lives on ubuntu-ports. Only defaulted when --mirror was not
+# given explicitly.
+$mirror    ||= ($arch ne 'amd64') ? 'http://ports.ubuntu.com/ubuntu-ports'
+                                  : 'http://br.archive.ubuntu.com/ubuntu';
 
 # --target "<codename>-<arch>" pins a single codename (and cross-checks the arch); otherwise --dists.
 my @dist_list;
-if ($dists =~ /-(amd64|ppc64el)$/) {
-    my ($cn, $a) = $dists =~ /^(.+)-(amd64|ppc64el)$/;
+if ($dists =~ /-(@{[join '|', supported_arches()]})$/) {
+    my ($cn, $a) = $dists =~ /^(.+)-(@{[join '|', supported_arches()]})$/;
     die "FATAL: --target arch '$a' != host --arch '$arch'\n" if $a ne $arch;
     @dist_list = ($cn);
 } else {
@@ -243,7 +245,7 @@ for my $cn (@dist_list) {
 
 @expect_arch = grep { length } map { split /[\s,]+/ } @expect_arch;
 for my $a (@expect_arch) {
-    die "FATAL: unsupported --expect-arch '$a' (amd64|ppc64el)\n" unless $a =~ /^(amd64|ppc64el)$/;
+    die "FATAL: unsupported --expect-arch '$a' (@{[join '|', supported_arches()]})\n" unless is_supported_arch($a);
 }
 
 # ---------------------------------------------------------------------------------------------------
@@ -604,7 +606,8 @@ sub maintained_genesis_control {
     my $f = "$xcat_src/xCAT-genesis-builder/debian/control";
     return undef unless -f $f;
     local $/; open my $fh, '<', $f or return undef; my $t = <$fh>; close $fh;
-    if ($a eq 'ppc64el') { $t =~ s/amd64/ppc64el/g; }
+    # The tree carries the amd64 control; any other arch is the same text with the arch renamed.
+    $t =~ s/amd64/$a/g if $a ne 'amd64';
     return $t;
 }
 # convert_genesis_rpm($rpm, $pkgname, $arch, $outdir): rpm2cpio-extract the noarch genesis rpm and

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -470,6 +470,37 @@ sub ensure_disposable_chroot {
     return 1;
 }
 
+# A chroot for another architecture is bootstrapped and built through qemu-user: debootstrap's
+# second stage and every later build run the target's own binaries. Without a registered binfmt
+# handler that fails deep inside debootstrap, so it is checked here, where the message can name what
+# is missing.
+my %BINFMT_HANDLER = (
+    riscv64 => 'qemu-riscv64',
+    ppc64el => 'qemu-ppc64le',
+);
+
+sub ensure_foreign_arch_support {
+    my ($target) = @_;
+
+    my $host = `dpkg --print-architecture 2>/dev/null`;
+    chomp $host;
+    return if (!$host or $target eq $host);
+
+    my $handler = $BINFMT_HANDLER{$target} or return;
+    my $node    = "/proc/sys/fs/binfmt_misc/$handler";
+    my $enabled = 0;
+    if (open my $fh, '<', $node) {
+        local $/;
+        $enabled = (<$fh> // '') =~ /^enabled/m ? 1 : 0;
+        close $fh;
+    }
+    return if $enabled;
+
+    die "FATAL: building $target on a $host host runs the target's binaries through qemu-user,\n"
+      . "       but the $handler binfmt handler is not registered (looked at $node).\n"
+      . "       Install qemu-user-static and binfmt-support, then re-run.\n";
+}
+
 sub ensure_chroots {
     print_step('Ensure sbuild chroots (auto-init on first run)');
     die "FATAL: chroot init requires root (uid=$>)\n" if $> != 0 && !$dry_run;
@@ -487,6 +518,7 @@ sub ensure_chroots {
             next;
         }
         print "  chroot $name: MISSING -> creating\n";
+        ensure_foreign_arch_support($arch);
         # debootstrap may lack a script for a new codename -> fall back to the generic one.
         run("[ -e /usr/share/debootstrap/scripts/$cn ] || ln -sf gutsy /usr/share/debootstrap/scripts/$cn", nofail => 1);
         my $root = "/srv/chroot/$cn-$arch";
@@ -1319,9 +1351,10 @@ sbuild-all.pl - build, validate, sign and assemble the xcat-dep Ubuntu/Debian ap
   sbuild-all.pl --arch amd64   --dists "focal jammy noble resolute" \
       --xcat-source ../xcat-core --genesis-rpm <xCAT-genesis-base rpm>
   sbuild-all.pl --arch ppc64el --dists "focal jammy noble resolute" --skip-genesis
+  sbuild-all.pl --arch riscv64 --dists "focal jammy noble resolute"
 
   # STEP 2 -- ONCE, after every arch has staged: assemble, sign, gate and publish atomically:
-  sbuild-all.pl --skip-build --skip-genesis --publish --expect-arch "amd64 ppc64el" \
+  sbuild-all.pl --skip-build --skip-genesis --publish --expect-arch "amd64 ppc64el riscv64" \
       --gpg-sign --gpg-key-id xcat@megware.com --gpg-home <gpg-home>
 
   # build ONE Ubuntu version only:
@@ -1334,7 +1367,7 @@ sbuild-all.pl - build, validate, sign and assemble the xcat-dep Ubuntu/Debian ap
 
   # verify an already-published tree out of band (signatures checked by DEFAULT):
   sbuild-all.pl --verify-repo <apt_dir> --dists "focal jammy noble resolute" \
-      --expect-arch "amd64 ppc64el" --gpg-key-id <id> --gpg-home <dir>
+      --expect-arch "amd64 ppc64el riscv64" --gpg-key-id <id> --gpg-home <dir>
 
   sbuild-all.pl --help        # option summary
   sbuild-all.pl --man         # this manual
@@ -1568,7 +1601,7 @@ that builds nothing (C<--skip-build>), which is the finalization step. C<--no-pu
 =item B<--expect-arch> C<< amd64|ppc64el|riscv64 >>
 
 The architecture set the published repo must serve, stated explicitly. Repeatable, and each value may
-be a space/comma list (C<--expect-arch "amd64 ppc64el">). Used by the gate: an expected arch with no
+be a space/comma list (C<--expect-arch "amd64 ppc64el riscv64">). Used by the gate: an expected arch with no
 native package is C<MISSING-ARCH>, an unexpected arch that published natives is C<UNEXPECTED-ARCH>,
 and C<Release> advertises exactly this set. Without it the gate falls back to the staged arch set when
 publishing, or to each codename's C<Release> C<Architectures:> when verifying standalone.

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -662,7 +662,10 @@ sub build_deps {
         }
         my $pid = wait();
         if ($pid > 0) {
-            my $ec = $? >> 8;
+            # A worker the kernel killed leaves 0 in the high byte, so the shifted status alone
+            # would record a cancelled or OOM-killed codename as built.
+            require XCAT::BuildUtils;
+            my $ec = XCAT::BuildUtils::exit_status($?);
             my $cn = delete $pid2cn{$pid} // '?';
             $fail{$cn} = $ec if $ec != 0;
             $running--;

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -652,6 +652,19 @@ sub convert_genesis_rpm {
     run("dpkg-deb --build " . sh_quote($pkgd) . " " . sh_quote("$outdir/${pkgname}_${ver}_all.deb"));
     return "$outdir/${pkgname}_${ver}_all.deb";
 }
+# genesis_in_manifest(): whether the legacy Genesis deb belongs to this run at all. It is named
+# per target in the manifest, and riscv64 does not name it: its Genesis is the OpenEmbedded package
+# published once into the shared pool. Without this, a plain --arch riscv64 run reaches
+# build_genesis and dies for want of a --genesis-deb it can never have, after the dep builds.
+sub genesis_in_manifest {
+    for my $cn (@dist_list) {
+        my $section = "$cn-$arch";
+        next unless $MANIFEST{$section};
+        return 1 if grep { /^xcat-genesis-base/ } keys %{ $MANIFEST{$section} };
+    }
+    return 0;
+}
+
 sub build_genesis {
     print_step('Genesis-base deb (maintained packaging preserved)');
     my $gen = "$output_root/$run_id/genesis"; wipe_tree($gen) if -d $gen; make_path($gen);
@@ -1287,7 +1300,7 @@ unless ($skip_build) {
     ensure_chroots();
     build_deps();
 }
-build_genesis()    unless $skip_genesis;
+build_genesis()    unless ($skip_genesis or !genesis_in_manifest());
 validate_manifest();
 publish_repo();      # no-op unless --publish (or a --skip-build finalization run); tarball is inside
 print_step("Completed ($arch: @dist_list)" . ($publish ? '' : ' -- staging only, not published'));

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -869,7 +869,7 @@ sub resolve_expect_arches {
             for my $d (glob("$staging/$cn/*")) {
                 next unless -d $d;
                 my $a = basename($d);
-                $u{$a} = 1 if $a =~ /^(amd64|ppc64el)$/;
+                $u{$a} = 1 if is_supported_arch($a);
             }
         }
         print "  expected arches (from the staged set): " . join(' ', sort keys %u) . "\n";
@@ -926,7 +926,7 @@ sub verify_assembled_repo {
         # pure verify_repo_arches can report both directions: expected-but-absent and present-but-
         # unexpected (a stale arch left behind in the tree).
         my %native;
-        for my $a (do { my %s = map { $_ => 1 } (@expected, qw(amd64 ppc64el)); sort keys %s }) {
+        for my $a (do { my %s = map { $_ => 1 } (@expected, supported_arches()); sort keys %s }) {
             my $idx = "$adir/dists/$cn/main/binary-$a/Packages";
             $native{$a} = 0;
             next unless -f $idx;
@@ -1438,7 +1438,7 @@ C<--skip-tarball>.
 
 =over 4
 
-=item B<--arch> C<amd64|ppc64el>
+=item B<--arch> C<amd64|ppc64el|riscv64>
 
 Host architecture. Default: C<dpkg --print-architecture>.
 
@@ -1552,7 +1552,7 @@ swap it onto C<--apt-dir> atomically. B<A build run does not publish unless this
 arches can build concurrently without racing each other on the shared repo. Defaults to on for a run
 that builds nothing (C<--skip-build>), which is the finalization step. C<--no-publish> forces it off.
 
-=item B<--expect-arch> C<< amd64|ppc64el >>
+=item B<--expect-arch> C<< amd64|ppc64el|riscv64 >>
 
 The architecture set the published repo must serve, stated explicitly. Repeatable, and each value may
 be a space/comma list (C<--expect-arch "amd64 ppc64el">). Used by the gate: an expected arch with no

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -594,7 +594,17 @@ sub build_one_codename {
             '>', sh_quote($log), '2>&1',
         );
         print "  [$cn] -> $pkg ($dir/sbuild.pl)\n";
-        my $ec = run($cmd, nofail => 1);
+        # run_bounded, not run(): it puts the builder in its own process group and forwards a
+        # signal to it. system() would leave the builder, its schroot session and qemu running
+        # after this worker died, holding the chroot and writing into staging. The wall-clock
+        # bound belongs to the builder itself, so this call only carries the cancellation.
+        print "+ $cmd\n";
+        my $ec = 0;
+        unless ($dry_run) {
+            require XCAT::BuildUtils;
+            $ec = XCAT::BuildUtils::run_bounded(cmd => $cmd, timeout => 0,
+                      label => "[$cn] $pkg", out => \*STDOUT)->{ec};
+        }
         if ($ec != 0) { warn "FATAL: [$cn] $pkg build failed (rc=$ec) -- see $log\n"; return 1; }
     }
     print "== [$cn] done ==\n";
@@ -633,7 +643,12 @@ sub build_deps {
             my $cn = shift @queue;
             my $pid = fork();
             die "FATAL: fork failed: $!\n" unless defined $pid;
-            if ($pid == 0) { exit(build_one_codename($cn)); }   # child
+            # The child must not inherit the parent's forwarder: its copy names sibling workers,
+            # which the parent already signals.
+            if ($pid == 0) {
+                $SIG{$_} = 'DEFAULT' for qw(INT TERM HUP);
+                exit(build_one_codename($cn));
+            }
             $pid2cn{$pid} = $cn; $running++;
         }
         my $pid = wait();

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -620,6 +620,14 @@ sub build_deps {
     my @queue = @dist_list;
     my (%pid2cn, %fail);
     my $running = 0;
+    require XCAT::BuildUtils;
+    my $forward = XCAT::BuildUtils::forward_signals_to_workers(
+        pids => \%pid2cn,
+        reap => sub { waitpid($_, 0) for keys %pid2cn },
+    );
+    local $SIG{INT}  = $forward;
+    local $SIG{TERM} = $forward;
+    local $SIG{HUP}  = $forward;
     while (@queue || $running) {
         while (@queue && $running < $max) {
             my $cn = shift @queue;

--- a/sbuild-all.pl
+++ b/sbuild-all.pl
@@ -641,15 +641,24 @@ sub build_deps {
     while (@queue || $running) {
         while (@queue && $running < $max) {
             my $cn = shift @queue;
+            # Block the handled signals across the fork AND the registration below: a cancellation
+            # in between would reach a handler that does not know this worker yet, and the worker
+            # would keep building for hours while holding the per-arch lock.
+            my $previous = XCAT::BuildUtils::block_handled_signals();
             my $pid = fork();
-            die "FATAL: fork failed: $!\n" unless defined $pid;
+            unless (defined $pid) {
+                XCAT::BuildUtils::restore_signal_mask($previous);
+                die "FATAL: fork failed: $!\n";
+            }
             # The child must not inherit the parent's forwarder: its copy names sibling workers,
             # which the parent already signals.
             if ($pid == 0) {
                 $SIG{$_} = 'DEFAULT' for qw(INT TERM HUP);
+                XCAT::BuildUtils::restore_signal_mask($previous);
                 exit(build_one_codename($cn));
             }
             $pid2cn{$pid} = $cn; $running++;
+            XCAT::BuildUtils::restore_signal_mask($previous);
         }
         my $pid = wait();
         if ($pid > 0) {

--- a/t/build_timeout.t
+++ b/t/build_timeout.t
@@ -1,0 +1,131 @@
+#!/usr/bin/perl
+# Behaviour test for the wall-clock bound on emulated build steps. It DRIVES run_bounded with a
+# command that hangs and asserts that the call returns, fails, and prints the evidence -- it never
+# reads the source of the thing it tests.
+#
+# Every call under test runs in a forked child whose stdio is detached to a file, and the parent
+# bounds that child itself. Without the bound in run_bounded the child would block forever; a child
+# holding this test's stdout would block prove instead of failing it, so the failure of the code
+# under test must show up as a FAILED assertion here, never as a hung suite.
+use strict;
+use warnings;
+
+use File::Temp qw(tempdir);
+use FindBin;
+use POSIX ();
+use Test::More;
+
+use lib "$FindBin::Bin/../lib", "$FindBin::Bin/..";
+use XCAT::BuildUtils qw(run_bounded emulated_build_timeout);
+use BuildUtils qw(chroot_build_timeout);
+
+my $tmp = tempdir(CLEANUP => 1);
+my @strays;
+# waitpid on an already-gone child sets $? to -1, and Test::Builder's END reads $? as the exit
+# status. Save it, or a clean run reports "exited with -1".
+END { local $?; for my $p (@strays) { kill('KILL', $p); waitpid($p, 0); } }
+
+# drive(): run one run_bounded call in a detached child and wait at most {deadline} seconds for it.
+# Returns the child's result plus whether it finished on its own -- "did not finish" is the assertion
+# that catches an unbounded run_bounded, which would otherwise hang this test.
+sub drive {
+    my (%a) = @_;
+    my $out = "$tmp/$a{name}.out";
+    my $res = "$tmp/$a{name}.res";
+    my $t0  = time;
+
+    my $pid = fork();
+    die "fork: $!" unless defined $pid;
+    if ($pid == 0) {
+        open(STDIN,  '<',  '/dev/null');
+        open(STDOUT, '>',  $out) or POSIX::_exit(90);
+        open(STDERR, '>&', \*STDOUT);
+        POSIX::setpgid(0, 0);
+        my $r = eval {
+            run_bounded(cmd => $a{cmd}, timeout => $a{timeout},
+                        sample => $a{sample}, label => $a{name}, out => \*STDOUT);
+        } || { ec => -99, timed_out => 0, elapsed => -1 };
+        if (open(my $fh, '>', $res)) { print {$fh} "$r->{ec} $r->{timed_out} $r->{elapsed}\n"; close($fh); }
+        POSIX::_exit(0);
+    }
+    POSIX::setpgid($pid, $pid);
+
+    my $deadline = $t0 + $a{deadline};
+    my $finished = 0;
+    while (time < $deadline) {
+        if (waitpid($pid, POSIX::WNOHANG()) == $pid) { $finished = 1; last; }
+        select(undef, undef, undef, 0.2);
+    }
+    # Reap unconditionally: an unreaped child keeps its group alive and the next test inherits it.
+    unless ($finished) { kill('KILL', -$pid); waitpid($pid, 0); }
+
+    my ($ec, $timed_out, $elapsed) = (-1, 0, -1);
+    if (open(my $fh, '<', $res)) { ($ec, $timed_out, $elapsed) = split(' ', <$fh> // ''); close($fh); }
+    my $text = '';
+    if (open(my $fh, '<', $out)) { local $/; $text = <$fh> // ''; close($fh); }
+    return { finished => $finished, ec => $ec, timed_out => $timed_out,
+             elapsed => $elapsed, out => $text, wall => time - $t0 };
+}
+
+# --- the budget itself -----------------------------------------------------------------------
+is(emulated_build_timeout('amd64', 'amd64'), 900, 'a native build gets the native budget');
+is(emulated_build_timeout('riscv64', 'amd64'), 9000,
+    'an emulated build gets ten times the native budget');
+{
+    local $ENV{XCAT_DEP_BUILD_TIMEOUT} = 42;
+    is(chroot_build_timeout('noble-riscv64-sbuild'), 42, 'XCAT_DEP_BUILD_TIMEOUT overrides the budget');
+}
+{
+    local %ENV = %ENV; delete $ENV{XCAT_DEP_BUILD_TIMEOUT};
+    is(chroot_build_timeout('noble-riscv64-sbuild'), 9000,
+        'a riscv64 chroot on this host derives the emulated budget');
+}
+
+# --- a command that exits normally is not touched --------------------------------------------
+my $ok = drive(name => 'exit0', cmd => 'exit 0', timeout => 60, sample => 1, deadline => 30);
+ok($ok->{finished}, 'a fast command returns');
+is($ok->{ec}, 0, 'its exit status is 0');
+is($ok->{timed_out}, 0, 'it is not reported as timed out');
+
+my $bad = drive(name => 'exit3', cmd => 'exit 3', timeout => 60, sample => 1, deadline => 30);
+is($bad->{ec}, 3, 'a failing command keeps its exit status');
+
+# --- THE DEFECT: a build that hangs must fail, within the budget, with evidence ---------------
+my $hang = drive(name => 'hang', cmd => 'exec sleep 600 >/dev/null 2>&1',
+                 timeout => 4, sample => 2, deadline => 90);
+ok($hang->{finished}, 'a hanging command does NOT hang the caller')
+    or BAIL_OUT('run_bounded never returned: the bound is missing, so a hung build has no failure');
+is($hang->{timed_out}, 1, 'the hang is reported as a timeout');
+is($hang->{ec}, 124, 'the timeout exit status is 124, as timeout(1) uses');
+cmp_ok($hang->{wall}, '<', 60, 'it fails soon after the budget, not later');
+like($hang->{out}, qr/exceeded its 4s budget/, 'the failure names the budget it exceeded');
+like($hang->{out}, qr/stall report: process group \d+/, 'it prints the process group');
+like($hang->{out}, qr/PID\s+PPID\s+STAT\s+TICKS\s+DELTA\s+WCHAN\s+CMD/, 'it prints the process tree');
+like($hang->{out}, qr/sockets: \d+/, 'it prints the open socket count');
+like($hang->{out}, qr/CPU ticks consumed by the whole group during the sample: 0/,
+    'it samples CPU ticks and finds none');
+like($hang->{out}, qr/DEADLOCKED, not slow/, 'it says the build was deadlocked rather than slow');
+
+# --- a busy build is reported differently, so the sample means something ----------------------
+my $busy = drive(name => 'busy', cmd => 'exec bash -c "while :; do :; done" >/dev/null 2>&1',
+                 timeout => 4, sample => 2, deadline => 90);
+ok($busy->{finished}, 'a spinning command is also bounded');
+is($busy->{timed_out}, 1, 'the spin is reported as a timeout');
+like($busy->{out}, qr/still consumes CPU/, 'a spinning build is NOT called deadlocked');
+unlike($busy->{out}, qr/DEADLOCKED/, 'the CPU sample distinguishes a slow build from a deadlock');
+
+# --- the whole process group dies, not just the shell ----------------------------------------
+my $pidfile = "$tmp/grandchild.pid";
+my $tree = drive(name => 'tree',
+                 cmd => "sleep 600 >/dev/null 2>&1 & echo \$! > $pidfile; wait",
+                 timeout => 4, sample => 1, deadline => 90);
+ok($tree->{finished}, 'a command with a child of its own is bounded too');
+my $gpid = 0;
+if (open(my $fh, '<', $pidfile)) { chomp($gpid = <$fh> // 0); close($fh); }
+ok($gpid > 0, 'the grandchild recorded its pid');
+push @strays, $gpid if $gpid > 0;
+my $alive = 1;
+for (1 .. 50) { $alive = (-d "/proc/$gpid") ? 1 : 0; last unless $alive; select(undef, undef, undef, 0.2); }
+is($alive, 0, 'the grandchild is killed with the group, so nothing survives holding the pipe');
+
+done_testing();

--- a/t/build_timeout.t
+++ b/t/build_timeout.t
@@ -226,4 +226,61 @@ is($alive, 0, 'the grandchild is killed with the group, so nothing survives hold
     }
 }
 
+# forward_signals_to_workers: the orchestrator forks its own workers, so run_bounded's forwarding
+# never sees a signal sent to it. Two real processes stand in for a worker and the build it runs.
+{
+    my $dir     = tempdir( CLEANUP => 1 );
+    my $pidfile = "$dir/worker.pid";
+
+    my $wrapper = fork();
+    die "fork failed: $!" unless defined $wrapper;
+    if ( $wrapper == 0 ) {
+        my %kids;
+        my $worker = fork();
+        if ( defined $worker && $worker == 0 ) {
+            open my $fh, '>', $pidfile or POSIX::_exit(1);
+            print {$fh} "$$\n";
+            close $fh;
+            sleep 300;
+            POSIX::_exit(0);
+        }
+        $kids{$worker} = 1;
+        my $forward = XCAT::BuildUtils::forward_signals_to_workers(
+            pids => \%kids,
+            reap => sub { waitpid( $_, 0 ) for keys %kids },
+        );
+        local $SIG{TERM} = $forward;
+        sleep 300;
+        POSIX::_exit(0);
+    }
+
+    my $worker;
+    for ( 1 .. 100 ) {
+        if ( -s $pidfile ) {
+            open my $fh, '<', $pidfile or last;
+            chomp( $worker = <$fh> // '' );
+            close $fh;
+            last if $worker;
+        }
+        select( undef, undef, undef, 0.1 );
+    }
+
+  SKIP: {
+        skip 'worker never reported its pid', 2 unless $worker;
+        ok( kill( 0, $worker ), 'the worker is running before the orchestrator is signalled' );
+
+        kill 'TERM', $wrapper;
+        waitpid( $wrapper, 0 );
+
+        my $alive = 1;
+        for ( 1 .. 100 ) {
+            $alive = kill( 0, $worker );
+            last unless $alive;
+            select( undef, undef, undef, 0.1 );
+        }
+        ok( !$alive, 'signalling the orchestrator reaps its forked workers' );
+        kill 'KILL', $worker if $alive;
+    }
+}
+
 done_testing;

--- a/t/build_timeout.t
+++ b/t/build_timeout.t
@@ -363,4 +363,41 @@ is($alive, 0, 'the grandchild is killed with the group, so nothing survives hold
     is( $r->{timed_out}, 0, '... and does not call it a timeout' );
 }
 
+# The leader of the build's process group can die without its descendants: a SIGKILL or the OOM
+# killer takes the shell and leaves schroot and qemu behind, still holding the chroot. They are not
+# children of this process, so nothing waits for them and nothing reported them.
+{
+    my $dir     = tempdir( CLEANUP => 1 );
+    my $pidfile = "$dir/descendant.pid";
+    my $r = run_bounded(
+        cmd     => "sleep 300 & echo \$! > '$pidfile'; kill -KILL \$\$",
+        timeout => 60,
+        label   => 'leader killed while a descendant runs',
+        out     => \*STDERR,
+    );
+    is( $r->{ec}, 137, 'the leader is reported as killed by SIGKILL' );
+
+    my $descendant;
+    for ( 1 .. 30 ) {
+        if ( -s $pidfile ) {
+            open my $fh, '<', $pidfile or last;
+            chomp( $descendant = <$fh> // '' );
+            close $fh;
+            last if $descendant;
+        }
+        select( undef, undef, undef, 0.1 );
+    }
+  SKIP: {
+        skip 'the descendant never reported its pid', 1 unless $descendant;
+        my $alive = 1;
+        for ( 1 .. 50 ) {
+            $alive = kill( 0, $descendant );
+            last unless $alive;
+            select( undef, undef, undef, 0.1 );
+        }
+        ok( !$alive, 'the descendant does not outlive the call' );
+        kill 'KILL', $descendant if $alive;
+    }
+}
+
 done_testing;

--- a/t/build_timeout.t
+++ b/t/build_timeout.t
@@ -128,4 +128,54 @@ my $alive = 1;
 for (1 .. 50) { $alive = (-d "/proc/$gpid") ? 1 : 0; last unless $alive; select(undef, undef, undef, 0.2); }
 is($alive, 0, 'the grandchild is killed with the group, so nothing survives holding the pipe');
 
-done_testing();
+# A signal to the orchestrator must reach the build. Without forwarding, the wrapper dies and
+# releases its locks while the build keeps running and writing into staging, so the next run races
+# an orphan it cannot see. The child records its own pid, the wrapper is terminated, and the pid is
+# probed afterwards.
+{
+    my $dir = tempdir( CLEANUP => 1 );
+    my $pidfile = "$dir/child.pid";
+
+    my $wrapper = fork();
+    die "fork failed: $!" unless defined $wrapper;
+    if ( $wrapper == 0 ) {
+        # long budget: the bound must NOT be what ends this run -- the signal must be
+        run_bounded(
+            cmd     => "echo \$\$ > '$pidfile'; exec sleep 300",
+            timeout => 600,
+            label   => 'cancellation probe',
+            out     => \*STDERR,
+        );
+        POSIX::_exit(0);
+    }
+
+    my $child;
+    for ( 1 .. 100 ) {
+        if ( -s $pidfile ) {
+            open my $fh, '<', $pidfile or last;
+            chomp( $child = <$fh> // '' );
+            close $fh;
+            last if $child;
+        }
+        select( undef, undef, undef, 0.1 );
+    }
+
+  SKIP: {
+        skip 'child never reported its pid', 2 unless $child;
+        ok( kill( 0, $child ), 'the build is running before the wrapper is signalled' );
+
+        kill 'TERM', $wrapper;
+        waitpid( $wrapper, 0 );
+
+        my $alive = 1;
+        for ( 1 .. 100 ) {
+            $alive = kill( 0, $child );
+            last unless $alive;
+            select( undef, undef, undef, 0.1 );
+        }
+        ok( !$alive, 'terminating the wrapper reaps the build it started' );
+        kill 'KILL', $child if $alive;
+    }
+}
+
+done_testing;

--- a/t/build_timeout.t
+++ b/t/build_timeout.t
@@ -283,4 +283,49 @@ is($alive, 0, 'the grandchild is killed with the group, so nothing survives hold
     }
 }
 
+# The build must not inherit a blocked signal mask: run_bounded blocks INT, TERM and HUP across
+# the fork so a cancellation cannot land before its handler exists, and a child that kept that mask
+# would ignore the very signal the forwarding relies on.
+{
+    my $dir = tempdir( CLEANUP => 1 );
+    my $out = "$dir/mask";
+    my $r = run_bounded(
+        cmd     => "grep ^SigBlk /proc/self/status > '$out'",
+        timeout => 30,
+        label   => 'signal mask probe',
+        out     => \*STDERR,
+    );
+    is( $r->{ec}, 0, 'the probe ran' );
+  SKIP: {
+        skip 'no /proc/self/status on this host', 1 unless -s $out;
+        open my $fh, '<', $out or die $!;
+        my $line = <$fh>;
+        close $fh;
+        my ($mask) = $line =~ /SigBlk:\s*([0-9a-f]+)/;
+        my $blocked = hex( $mask // 'ffffffffffffffff' );
+        # bit n-1 is signal n: INT 2, TERM 15, HUP 1
+        my $handled = ( 1 << 1 ) | ( 1 << 14 ) | ( 1 << 0 );
+        is( $blocked & $handled, 0, 'the build starts with INT, TERM and HUP unblocked' );
+    }
+}
+
+# The caller's own mask must be restored: run_bounded blocks INT, TERM and HUP around the fork, and
+# leaving them blocked would make the orchestrator ignore a cancellation for the rest of the run.
+{
+    my $dir = tempdir( CLEANUP => 1 );
+    my $out = "$dir/caller-mask";
+    run_bounded( cmd => 'true', timeout => 30, label => 'mask restore probe', out => \*STDERR );
+    system("grep ^SigBlk /proc/self/status > '$out' 2>/dev/null");
+  SKIP: {
+        skip 'no /proc/self/status on this host', 1 unless -s $out;
+        open my $fh, '<', $out or die $!;
+        my $line = <$fh>;
+        close $fh;
+        my ($mask) = $line =~ /SigBlk:\s*([0-9a-f]+)/;
+        my $blocked = hex( $mask // 'ffffffffffffffff' );
+        my $handled = ( 1 << 1 ) | ( 1 << 14 ) | ( 1 << 0 );
+        is( $blocked & $handled, 0, 'the caller keeps INT, TERM and HUP unblocked afterwards' );
+    }
+}
+
 done_testing;

--- a/t/build_timeout.t
+++ b/t/build_timeout.t
@@ -178,4 +178,52 @@ is($alive, 0, 'the grandchild is killed with the group, so nothing survives hold
     }
 }
 
+# The same must hold with no deadline. An unbounded run used to call system(), which leaves the
+# build in the orchestrator's own process group: a directed signal then killed the orchestrator and
+# left the build writing into staging.
+{
+    my $dir     = tempdir( CLEANUP => 1 );
+    my $pidfile = "$dir/child.pid";
+
+    my $wrapper = fork();
+    die "fork failed: $!" unless defined $wrapper;
+    if ( $wrapper == 0 ) {
+        run_bounded(
+            cmd     => "echo \$\$ > '$pidfile'; exec sleep 300",
+            timeout => 0,
+            label   => 'unbounded cancellation probe',
+            out     => \*STDERR,
+        );
+        POSIX::_exit(0);
+    }
+
+    my $child;
+    for ( 1 .. 100 ) {
+        if ( -s $pidfile ) {
+            open my $fh, '<', $pidfile or last;
+            chomp( $child = <$fh> // '' );
+            close $fh;
+            last if $child;
+        }
+        select( undef, undef, undef, 0.1 );
+    }
+
+  SKIP: {
+        skip 'child never reported its pid', 2 unless $child;
+        ok( kill( 0, $child ), 'the unbounded build is running before the wrapper is signalled' );
+
+        kill 'TERM', $wrapper;
+        waitpid( $wrapper, 0 );
+
+        my $alive = 1;
+        for ( 1 .. 100 ) {
+            $alive = kill( 0, $child );
+            last unless $alive;
+            select( undef, undef, undef, 0.1 );
+        }
+        ok( !$alive, 'terminating the wrapper reaps an unbounded build too' );
+        kill 'KILL', $child if $alive;
+    }
+}
+
 done_testing;

--- a/t/build_timeout.t
+++ b/t/build_timeout.t
@@ -16,7 +16,7 @@ use POSIX ();
 use Test::More;
 
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/..";
-use XCAT::BuildUtils qw(run_bounded emulated_build_timeout);
+use XCAT::BuildUtils qw(run_bounded emulated_build_timeout block_handled_signals restore_signal_mask);
 use BuildUtils qw(chroot_build_timeout);
 
 my $tmp = tempdir(CLEANUP => 1);
@@ -326,6 +326,23 @@ is($alive, 0, 'the grandchild is killed with the group, so nothing survives hold
         my $handled = ( 1 << 1 ) | ( 1 << 14 ) | ( 1 << 0 );
         is( $blocked & $handled, 0, 'the caller keeps INT, TERM and HUP unblocked afterwards' );
     }
+}
+
+# block_handled_signals holds a cancellation until the caller can act on it. This is the window
+# between forking a worker and being able to signal it: delivered there, the signal kills the parent
+# under a handler that does not know the child, and the child keeps building.
+{
+    my @caught;
+    local $SIG{TERM} = sub { push @caught, 'TERM' };
+
+    my $previous = block_handled_signals();
+    kill 'TERM', $$;
+    select( undef, undef, undef, 0.2 );
+    is_deeply( \@caught, [], 'a signal sent while blocked is not delivered' );
+
+    restore_signal_mask($previous);
+    select( undef, undef, undef, 0.2 );
+    is_deeply( \@caught, ['TERM'], '... and arrives once the mask is restored' );
 }
 
 done_testing;

--- a/t/build_timeout.t
+++ b/t/build_timeout.t
@@ -16,7 +16,7 @@ use POSIX ();
 use Test::More;
 
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/..";
-use XCAT::BuildUtils qw(run_bounded emulated_build_timeout block_handled_signals restore_signal_mask);
+use XCAT::BuildUtils qw(run_bounded emulated_build_timeout block_handled_signals restore_signal_mask exit_status);
 use BuildUtils qw(chroot_build_timeout);
 
 my $tmp = tempdir(CLEANUP => 1);
@@ -343,6 +343,24 @@ is($alive, 0, 'the grandchild is killed with the group, so nothing survives hold
     restore_signal_mask($previous);
     select( undef, undef, undef, 0.2 );
     is_deeply( \@caught, ['TERM'], '... and arrives once the mask is restored' );
+}
+
+# A child the kernel kills leaves 0 in the high byte of its wait status. Reading only that byte
+# reports a cancelled or OOM-killed build as one that succeeded, which is what the orchestrators do
+# with the status wait() gives them.
+{
+    is( exit_status(0),    0,   'a child that exited 0 reports 0' );
+    is( exit_status(256),  1,   'a child that exited 1 reports 1' );
+    is( exit_status(65280), 255, 'a child that exited 255 reports 255' );
+    is( exit_status(15),   143, 'a child killed by TERM reports 128 plus the signal' );
+    is( exit_status(9),    137, 'a child killed by KILL reports 128 plus the signal' );
+    is( exit_status(139),  139, 'a segfault with a core dump still reports the signal' );
+
+    # The same status through the bounded path, so the helper and its caller agree.
+    my $r = run_bounded( cmd => 'kill -TERM $$', timeout => 30, label => 'signal exit',
+                         out => \*STDERR );
+    is( $r->{ec}, 143, 'run_bounded reports a signalled command the same way' );
+    is( $r->{timed_out}, 0, '... and does not call it a timeout' );
 }
 
 done_testing;

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -619,8 +619,6 @@ STUB
         'missing_perl_modules: an absent module is reported');
 }
 
-done_testing;
-
 # ---- every compiled dep must be buildable on every architecture xcat-dep supports -------------
 # A debian/control that names architectures explicitly silently excludes the ones it omits:
 # debhelper prints "No packages to build. Possible architecture mismatch: <arch>, want: <list>",
@@ -647,3 +645,5 @@ done_testing;
         }
     }
 }
+
+done_testing;

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -646,4 +646,41 @@ STUB
     }
 }
 
+# ---- every non-glob manifest pin must match the package's own debian/changelog --------------
+# debs-manifest.conf pins the exact deb version each package must produce, and the version comes
+# from that package's debian/changelog. Bumping the changelog without the pin does not fail the
+# build -- it fails the manifest VALIDATION, at the end, after every package has been compiled:
+#   FATAL: manifest validation failed:
+#     [noble-amd64] grub2-xcat: built 2.12-2, manifest pins 2.12-1
+# which is a whole build's worth of time to learn about a one-line edit. grub2-xcat drifted exactly
+# that way when the riscv64 UEFI image was added. Globbed pins are deliberate (goconserver's
+# revision is the CD stamp; xcat-genesis-base is not versioned by xcat-dep) and are skipped.
+{
+    my $root = "$FindBin::Bin/..";
+    my %dir_of = (
+        'ipmitool-xcat'  => 'ipmitool',
+        'conserver-xcat' => 'conserver',
+        'syslinux-xcat'  => 'syslinux',
+        'grub2-xcat'     => 'grub2-xcat',
+        'elilo-xcat'     => 'elilo',
+        'xnba-undi'      => 'xnba',
+    );
+    my %manifest = read_manifest("$root/debs-manifest.conf");
+    my %seen;
+    for my $section (sort keys %manifest) {
+        for my $pkg (sort keys %{ $manifest{$section} }) {
+            my $pin = $manifest{$section}{$pkg};
+            next if !defined $pin || $pin =~ /[*?]/;
+            my $dir = $dir_of{$pkg} or next;
+            my $cl  = "$root/$dir/debian/changelog";
+            next unless -f $cl;
+            open my $fh, '<', $cl or next;
+            my $first = <$fh>; close $fh;
+            my ($ver) = $first =~ /^\S+\s+\(([^)]+)\)/;
+            next if $seen{"$pkg=$pin=$ver"}++;
+            is($pin, $ver, "manifest pin $pkg=$pin matches $dir/debian/changelog");
+        }
+    }
+}
+
 done_testing;

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -17,6 +17,7 @@ use BuildUtils qw(install_deps_packages install_deps_command missing_perl_module
                   verify_repo_packages verify_repo_signature verify_repo_arches
                   parse_packages_index parse_release_architectures resolve_present_names
                   index_has_native_arch control_binary_arch skip_arch_all_on
+                  supported_arches
                   codename_to_version version_to_codename known_codenames
                   chroot_name chroot_sources_list chroot_is_disposable chroot_build_script
                   control_field genesis_deb_control
@@ -619,3 +620,30 @@ STUB
 }
 
 done_testing;
+
+# ---- every compiled dep must be buildable on every architecture xcat-dep supports -------------
+# A debian/control that names architectures explicitly silently excludes the ones it omits:
+# debhelper prints "No packages to build. Possible architecture mismatch: <arch>, want: <list>",
+# builds nothing, and the build then dies at ./configure. ipmitool-xcat did exactly that on
+# riscv64. The Architecture:all packages are the single-producer boot components and are excluded
+# here: they are built once on amd64 and never rebuilt per arch.
+{
+    my $root = "$FindBin::Bin/..";
+    for my $pkg (qw(ipmitool conserver goconserver)) {
+        my $ctl = "$root/$pkg/debian/control";
+        SKIP: {
+            skip "$pkg has no debian/control", 1 unless -f $ctl;
+            open my $fh, '<', $ctl or die "read $ctl: $!";
+            local $/; my $text = <$fh>; close $fh;
+            my @arch_lines = ($text =~ /^Architecture:\s*(.+)$/mg);
+            my @explicit = grep { !/^(?:any|all)$/ } map { s/^\s+|\s+$//gr } @arch_lines;
+            my @missing;
+            for my $line (@explicit) {
+                my %have = map { $_ => 1 } split /\s+/, $line;
+                push @missing, grep { !$have{$_} } grep { $_ ne 'amd64' } supported_arches();
+            }
+            is_deeply(\@missing, [],
+                "$pkg/debian/control builds on every supported arch (@{[join ' ', supported_arches()]})");
+        }
+    }
+}

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -603,6 +603,12 @@ STUB
     for my $need (qw(libfile-slurper-perl libparallel-forkmanager-perl sbuild schroot apt-utils dpkg-dev)) {
         ok(scalar(grep { $_ eq $need } @pkgs), "prerequisites include $need");
     }
+    # ensure_foreign_arch_support() refuses to bootstrap a foreign chroot without the binfmt
+    # handler and names these two packages, so --install-deps has to be the fix it points at.
+    for my $need (qw(qemu-user-static binfmt-support)) {
+        ok(scalar(grep { $_ eq $need } @pkgs), "prerequisites include $need");
+    }
+
     my @cmd = install_deps_command();
     is($cmd[0], 'apt-get', 'installs with apt-get');
     ok(scalar(grep { $_ eq '-y' } @cmd), '... non-interactively');

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -717,4 +717,39 @@ STUB
         'a staged tree for an unsupported architecture is still ignored' );
 }
 
+# The legacy Genesis deb is named per target in the manifest, and riscv64 does not name it: its
+# Genesis is the OpenEmbedded package published once into the shared pool. build_genesis ran for
+# every architecture, so a plain --arch riscv64 run died for want of a --genesis-deb it can never
+# have -- and only after the dependency builds had finished.
+{
+    my $src = do {
+        open my $fh, '<', "$FindBin::Bin/../sbuild-all.pl" or die $!;
+        local $/; <$fh>;
+    };
+
+    my ($sub) = $src =~ /\n(sub genesis_in_manifest \{\n.*?\n\})\n/ms;
+    BAIL_OUT('could not extract genesis_in_manifest from sbuild-all.pl') unless defined $sub;
+
+    our %MANIFEST = (
+        'noble-amd64'   => { 'xcat-genesis-base' => '2.*', 'ipmitool-xcat' => '1.8.18-4' },
+        'noble-ppc64el' => { 'xcat-genesis-base' => '2.*' },
+        'noble-riscv64' => { 'ipmitool-xcat' => '1.8.18-4', 'goconserver' => '0.3.3-snap*' },
+    );
+    our @dist_list = ('noble');
+    our $arch;
+
+    ## no critic (BuiltinFunctions::ProhibitStringyEval)
+    eval "$sub 1" or die "failed to evaluate genesis_in_manifest: $@";
+    ## use critic
+
+    $arch = 'amd64';
+    ok( genesis_in_manifest(), 'amd64 names the legacy Genesis deb, so that phase runs' );
+    $arch = 'ppc64el';
+    ok( genesis_in_manifest(), 'ppc64el names it too' );
+    $arch = 'riscv64';
+    ok( !genesis_in_manifest(), 'riscv64 does not, so the legacy Genesis phase is skipped' );
+    $arch = 's390x';
+    ok( !genesis_in_manifest(), 'a target with no manifest section does not demand Genesis' );
+}
+
 done_testing;

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -17,7 +17,7 @@ use BuildUtils qw(install_deps_packages install_deps_command missing_perl_module
                   verify_repo_packages verify_repo_signature verify_repo_arches
                   parse_packages_index parse_release_architectures resolve_present_names
                   index_has_native_arch control_binary_arch skip_arch_all_on
-                  supported_arches
+                  supported_arches is_supported_arch
                   codename_to_version version_to_codename known_codenames
                   chroot_name chroot_sources_list chroot_is_disposable chroot_build_script
                   control_field genesis_deb_control
@@ -681,6 +681,40 @@ STUB
             is($pin, $ver, "manifest pin $pkg=$pin matches $dir/debian/changelog");
         }
     }
+}
+
+# In publish mode with no --expect-arch, the expected set is discovered by scanning the staged
+# tree. That scan admitted a hardcoded amd64|ppc64el, so a staged riscv64 tree was dropped and
+# the arch never reached the code that writes its binary-<arch> index and names it in Release.
+# The scan is extracted from the script and driven here, so the test tracks the shipped code.
+{
+    my $src = do {
+        open my $fh, '<', "$FindBin::Bin/../sbuild-all.pl" or die $!;
+        local $/; <$fh>;
+    };
+
+    my ($scan) = $src =~ /\n(    my %u = \(\$arch => 1\);\n    if \(\$mode eq 'publish'\) \{\n.*?\n        \}\n)/ms;
+    BAIL_OUT('could not extract the staged-arch scan from sbuild-all.pl') unless defined $scan;
+
+    my $staging = tempdir( CLEANUP => 1 );
+    make_path("$staging/noble/$_") for qw(amd64 ppc64el riscv64 s390x);
+
+    my ( $arch, $mode ) = ( 'amd64', 'publish' );
+    my @dist_list = ('noble');
+    my %u;
+    ## no critic (BuiltinFunctions::ProhibitStringyEval)
+    # the extracted text ends inside the publish branch, so the brace closes it; the branch's
+    # print is deliberately left out, because it would land in the middle of the TAP stream
+    my $got = eval "$scan }\n[sort keys %u]";
+    ## use critic
+    die "failed to evaluate the staged-arch scan: $@" if $@;
+
+    is_deeply( $got, [ sort( supported_arches() ) ],
+        'every supported architecture staged for a codename is expected' );
+    ok( ( grep { $_ eq 'riscv64' } @$got ),
+        'a staged riscv64 tree reaches the expected set' );
+    ok( !( grep { $_ eq 's390x' } @$got ),
+        'a staged tree for an unsupported architecture is still ignored' );
 }
 
 done_testing;

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -568,6 +568,15 @@ if [ -n "$FAKE_SMOKE_MARK" ]; then
                           exit ${FAKE_SMOKE_RC:-0} ;;
   esac
 fi
+# A build session leaves its debs in the result directory it was given, which is the private
+# staging directory build_deb_in_chroot creates and passes among the session arguments.
+if [ -n "$FAKE_BUILD_DEB" ]; then
+  for arg in "$@"; do
+    case "$arg" in
+      */.build-*) [ -d "$arg" ] && : > "$arg/$FAKE_BUILD_DEB" ;;
+    esac
+  done
+fi
 exit 0
 STUB
     close $fh;
@@ -601,19 +610,13 @@ STUB
 
     # ---- the post-build smoke -------------------------------------------------------------------
     # A cross-built binary runs only in the chroot, so the smoke is the ONLY check that the deb
-    # carries a runnable binary. Same stub, now standing in for the chroot session, with a deb
-    # planted so the build gets as far as the smoke.
+    # carries a runnable binary. The stub now leaves a deb behind like a real build session, so
+    # the build gets as far as the smoke.
     {
         local $ENV{PATH} = "$fakebin:$ENV{PATH}";
         local $ENV{FAKE_SCHROOT_CONFIG} =
             "[noble-amd64-sbuild]\ntype=directory\ndirectory=/srv/chroot/noble-amd64\nunion-type=overlay\n";
-        # A failed smoke removes the deb it rejected, so each case plants a fresh one.
-        my $plant = sub {
-            open my $dfh, '>', "$work/out/fixture-xcat_1.8.18-4_amd64.deb" or die $!;
-            print {$dfh} "not really a deb\n";
-            close $dfh;
-        };
-        $plant->();
+        local $ENV{FAKE_BUILD_DEB} = 'fixture-xcat_1.8.18-4_amd64.deb';
 
         my %smoke = (deb => qr/^fixture-xcat_/, run => '/opt/xcat/bin/fixture-xcat -V',
                      expect => qr/fixture-xcat version 1\.8\.18/);
@@ -627,32 +630,32 @@ STUB
             or diag($@);
         ok(!-e "$work/out/.smoke-fixture.log", '... and the smoke log is removed on success');
 
+        # The passing case above published its deb; clear it so the next assertion is about what
+        # THIS run leaves behind.
+        unlink glob("$work/out/*.deb");
+
         local $ENV{FAKE_SMOKE_OUT} = 'fixture-xcat version 1.8.17';
         $ok = eval { quiet { build_deb_in_chroot(@args, smoke => \%smoke) }; 1 };
         ok(!$ok, 'a binary reporting another version fails the smoke');
         like($@, qr/does not match/, '... naming the expectation it missed');
 
-        # The debs are already in staging when the smoke runs, and the publish gate checks names
-        # and versions only. One left behind is the broken binary the smoke exists to catch.
+        # The publish gate checks names and versions only, so a deb the smoke rejected must never
+        # reach the directory a publish assembles from.
         is_deeply([ glob("$work/out/*.deb") ], [],
-            '... and the deb it rejected is gone from the result directory');
-        like($@, qr/were removed from/, '... which the failure says');
+            '... and no deb reaches the result directory');
 
-        $plant->();
 
         local $ENV{FAKE_SMOKE_OUT} = 'fixture-xcat version 1.8.18';
         local $ENV{FAKE_SMOKE_RC}  = 3;
         $ok = eval { quiet { build_deb_in_chroot(@args, smoke => \%smoke) }; 1 };
         ok(!$ok, 'a binary that cannot run fails the smoke even with matching output');
         like($@, qr/smoke failed \(rc=3\)/, '... reporting the exit status');
-        $plant->();
 
         delete local $ENV{FAKE_SMOKE_RC};
         $ok = eval { quiet { build_deb_in_chroot(@args,
                         smoke => { %smoke, deb => qr/^nosuchpkg_/ }) }; 1 };
         ok(!$ok, 'a smoke that names a deb the build never produced fails');
         like($@, qr/no produced deb matches/, '... instead of silently skipping the check');
-        $plant->();
 
         # --skip-install is what sbuild-all.pl passes to drop the smoke, so the same build with no
         # smoke must still succeed -- otherwise the tests above would pass for the wrong reason.

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -607,8 +607,13 @@ STUB
         local $ENV{PATH} = "$fakebin:$ENV{PATH}";
         local $ENV{FAKE_SCHROOT_CONFIG} =
             "[noble-amd64-sbuild]\ntype=directory\ndirectory=/srv/chroot/noble-amd64\nunion-type=overlay\n";
-        open my $dfh, '>', "$work/out/fixture-xcat_1.8.18-4_amd64.deb" or die $!;
-        print $dfh "not really a deb\n"; close $dfh;
+        # A failed smoke removes the deb it rejected, so each case plants a fresh one.
+        my $plant = sub {
+            open my $dfh, '>', "$work/out/fixture-xcat_1.8.18-4_amd64.deb" or die $!;
+            print {$dfh} "not really a deb\n";
+            close $dfh;
+        };
+        $plant->();
 
         my %smoke = (deb => qr/^fixture-xcat_/, run => '/opt/xcat/bin/fixture-xcat -V',
                      expect => qr/fixture-xcat version 1\.8\.18/);
@@ -627,17 +632,27 @@ STUB
         ok(!$ok, 'a binary reporting another version fails the smoke');
         like($@, qr/does not match/, '... naming the expectation it missed');
 
+        # The debs are already in staging when the smoke runs, and the publish gate checks names
+        # and versions only. One left behind is the broken binary the smoke exists to catch.
+        is_deeply([ glob("$work/out/*.deb") ], [],
+            '... and the deb it rejected is gone from the result directory');
+        like($@, qr/were removed from/, '... which the failure says');
+
+        $plant->();
+
         local $ENV{FAKE_SMOKE_OUT} = 'fixture-xcat version 1.8.18';
         local $ENV{FAKE_SMOKE_RC}  = 3;
         $ok = eval { quiet { build_deb_in_chroot(@args, smoke => \%smoke) }; 1 };
         ok(!$ok, 'a binary that cannot run fails the smoke even with matching output');
         like($@, qr/smoke failed \(rc=3\)/, '... reporting the exit status');
+        $plant->();
 
         delete local $ENV{FAKE_SMOKE_RC};
         $ok = eval { quiet { build_deb_in_chroot(@args,
                         smoke => { %smoke, deb => qr/^nosuchpkg_/ }) }; 1 };
         ok(!$ok, 'a smoke that names a deb the build never produced fails');
         like($@, qr/no produced deb matches/, '... instead of silently skipping the check');
+        $plant->();
 
         # --skip-install is what sbuild-all.pl passes to drop the smoke, so the same build with no
         # smoke must still succeed -- otherwise the tests above would pass for the wrong reason.

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -562,6 +562,12 @@ case "$1" in
   -l)       echo "chroot:noble-amd64-sbuild"; exit 0 ;;
   --config) printf '%s\n' "$FAKE_SCHROOT_CONFIG";  exit 0 ;;
 esac
+if [ -n "$FAKE_SMOKE_MARK" ]; then
+  case "$*" in
+    *"$FAKE_SMOKE_MARK"*) [ -n "$FAKE_SMOKE_OUT" ] && printf '%s\n' "$FAKE_SMOKE_OUT"
+                          exit ${FAKE_SMOKE_RC:-0} ;;
+  esac
+fi
 exit 0
 STUB
     close $fh;
@@ -591,6 +597,53 @@ STUB
         ok(!$ok, 'a disposable chroot gets past the guard (and then fails for another reason)');
         unlike($@, qr/is NOT disposable/, '... the failure is NOT the disposability guard');
         like($@, qr/no \.deb is visible/, '... it is the host-side "debs did not land" check');
+    }
+
+    # ---- the post-build smoke -------------------------------------------------------------------
+    # A cross-built binary runs only in the chroot, so the smoke is the ONLY check that the deb
+    # carries a runnable binary. Same stub, now standing in for the chroot session, with a deb
+    # planted so the build gets as far as the smoke.
+    {
+        local $ENV{PATH} = "$fakebin:$ENV{PATH}";
+        local $ENV{FAKE_SCHROOT_CONFIG} =
+            "[noble-amd64-sbuild]\ntype=directory\ndirectory=/srv/chroot/noble-amd64\nunion-type=overlay\n";
+        open my $dfh, '>', "$work/out/fixture-xcat_1.8.18-4_amd64.deb" or die $!;
+        print $dfh "not really a deb\n"; close $dfh;
+
+        my %smoke = (deb => qr/^fixture-xcat_/, run => '/opt/xcat/bin/fixture-xcat -V',
+                     expect => qr/fixture-xcat version 1\.8\.18/);
+        # The stub stands in for the whole chroot session, so it must answer the smoke without
+        # answering the build: only the smoke session carries the command being run.
+        local $ENV{FAKE_SMOKE_MARK} = $smoke{run};
+
+        local $ENV{FAKE_SMOKE_OUT} = 'fixture-xcat version 1.8.18';
+        my $ok = eval { quiet { build_deb_in_chroot(@args, smoke => \%smoke) }; 1 };
+        ok($ok, 'a deb whose binary runs and reports the expected version passes the smoke')
+            or diag($@);
+        ok(!-e "$work/out/.smoke-fixture.log", '... and the smoke log is removed on success');
+
+        local $ENV{FAKE_SMOKE_OUT} = 'fixture-xcat version 1.8.17';
+        $ok = eval { quiet { build_deb_in_chroot(@args, smoke => \%smoke) }; 1 };
+        ok(!$ok, 'a binary reporting another version fails the smoke');
+        like($@, qr/does not match/, '... naming the expectation it missed');
+
+        local $ENV{FAKE_SMOKE_OUT} = 'fixture-xcat version 1.8.18';
+        local $ENV{FAKE_SMOKE_RC}  = 3;
+        $ok = eval { quiet { build_deb_in_chroot(@args, smoke => \%smoke) }; 1 };
+        ok(!$ok, 'a binary that cannot run fails the smoke even with matching output');
+        like($@, qr/smoke failed \(rc=3\)/, '... reporting the exit status');
+
+        delete local $ENV{FAKE_SMOKE_RC};
+        $ok = eval { quiet { build_deb_in_chroot(@args,
+                        smoke => { %smoke, deb => qr/^nosuchpkg_/ }) }; 1 };
+        ok(!$ok, 'a smoke that names a deb the build never produced fails');
+        like($@, qr/no produced deb matches/, '... instead of silently skipping the check');
+
+        # --skip-install is what sbuild-all.pl passes to drop the smoke, so the same build with no
+        # smoke must still succeed -- otherwise the tests above would pass for the wrong reason.
+        local $ENV{FAKE_SMOKE_OUT} = 'irrelevant';
+        $ok = eval { quiet { build_deb_in_chroot(@args) }; 1 };
+        ok($ok, 'without a smoke the same build succeeds');
     }
 }
 

--- a/t/sbuild-all.t
+++ b/t/sbuild-all.t
@@ -752,4 +752,50 @@ STUB
     ok( !genesis_in_manifest(), 'a target with no manifest section does not demand Genesis' );
 }
 
+# A foreign-architecture chroot is bootstrapped and built through qemu-user, so a missing binfmt
+# handler has to be reported here rather than deep inside debootstrap. The check is extracted from
+# the script and driven with the handler node redirected into a temporary tree.
+{
+    my $src = do {
+        open my $fh, '<', "$FindBin::Bin/../sbuild-all.pl" or die $!;
+        local $/; <$fh>;
+    };
+
+    my ($sub) = $src =~ /\n(sub ensure_foreign_arch_support \{\n.*?\n\})\n/ms;
+    BAIL_OUT('could not extract ensure_foreign_arch_support from sbuild-all.pl') unless defined $sub;
+
+    my ($map) = $src =~ /\n(my %BINFMT_HANDLER = \(.*?\);)\n/ms;
+    BAIL_OUT('could not extract the binfmt handler map') unless defined $map;
+
+    my $fake = tempdir( CLEANUP => 1 );
+    ( my $driver = "$map\n$sub" ) =~ s{/proc/sys/fs/binfmt_misc}{$fake}g;
+    ## no critic (BuiltinFunctions::ProhibitStringyEval)
+    eval "$driver 1" or die "failed to evaluate ensure_foreign_arch_support: $@";
+    ## use critic
+
+    my $host = `dpkg --print-architecture 2>/dev/null`;
+    chomp $host;
+
+  SKIP: {
+        skip 'needs dpkg to report a host architecture', 3 unless $host;
+
+        # the host's own architecture never needs emulation
+        eval { ensure_foreign_arch_support($host) };
+        is( $@, '', 'a native build does not ask for a binfmt handler' );
+
+        my $foreign = $host eq 'riscv64' ? 'ppc64el' : 'riscv64';
+        my $handler = $foreign eq 'riscv64' ? 'qemu-riscv64' : 'qemu-ppc64le';
+
+        eval { ensure_foreign_arch_support($foreign) };
+        like( $@, qr/binfmt handler is not registered/,
+            "a foreign $foreign build without the handler is refused" );
+
+        open my $fh, '>', "$fake/$handler" or die $!;
+        print {$fh} "enabled\ninterpreter /usr/libexec/qemu-binfmt/$handler\nflags: POF\n";
+        close $fh;
+        eval { ensure_foreign_arch_support($foreign) };
+        is( $@, '', "a foreign $foreign build with the handler registered proceeds" );
+    }
+}
+
 done_testing;


### PR DESCRIPTION
The Ubuntu dependency repository carried no riscv64 packages. sbuild-all.pl
built amd64 and ppc64el only, so an apt management node on riscv64 had nothing
to install.

Build and stage riscv64. The chroot bootstraps through the qemu-user binfmt
handler, which --install-deps now installs. Report a missing handler before the
bootstrap starts, rather than leaving it to fail inside debootstrap's second
stage. Only amd64 and i386 are on archive.ubuntu.com, and the bootstrap mirror
follows the architecture.

Install each produced deb into the chroot that built it, and run its binary
there. Nothing on the build host can run a cross-built binary: it links against
the target loader. That check found one. ipmitool-xcat listed its library
dependencies by hand and never used ${shlibs:Depends}, so its riscv64 package
installed and then failed on a missing libreadline.so.8. The revision moves to
1.8.18-5 on every architecture. A deb that fails the check no longer reaches
staging.